### PR TITLE
 Fix issue with cursorless list argument to gpt_query

### DIFF
--- a/GPT/beta-commands/gpt-function-calling.py
+++ b/GPT/beta-commands/gpt-function-calling.py
@@ -24,7 +24,6 @@ def gpt_function_query(
     insert_response: InsertOption = InsertOption.PASTE,
     cursorless_destination: Optional[Any] = None,
 ) -> None:
-
     # Function calling likely to not be supported in local models so better to use OpenAI
     url = "https://api.openai.com/v1/chat/completions"
 

--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -95,8 +95,13 @@ class UserActions:
         actions.user.paste(text_to_confirm)
         confirmation_gui.hide()
 
-    def gpt_apply_prompt(prompt: str, text_to_process: str) -> str:
+    def gpt_apply_prompt(prompt: str, text_to_process: str | list[str]) -> str:
         """Apply an arbitrary prompt to arbitrary text"""
+        text_to_process = (
+            " ".join(text_to_process)
+            if isinstance(text_to_process, list)
+            else text_to_process
+        )
         return gpt_query(prompt, text_to_process)
 
     def gpt_help():


### PR DESCRIPTION
The function did not correctly take in a list of strings as the argument. Cursorless outputs puts a list of strings when you select a range. Changed to convert to strings