### PR TITLE
Support for Different Shells

### DIFF
--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -63,13 +63,16 @@ class UserActions:
 
     def gpt_generate_shell(text_to_process: str) -> str:
         """Generate a shell command from a spoken instruction"""
-        prompt = """
-        Generate a unix shell command that will perform the given task.
-        Only include the code and not any natural language comments or explanations.
+        shell_name = settings.get("user.model_shell_default")
+        if shell_name == None:
+            raise Exception("GPT Error: Shell name is not set. Set it in the settings.")
+
+        prompt = f"""
+        Generate a {shell_name} shell command that will perform the given task.
+        Only include the code. Do not include any comments, backticks, or natural language explanations. Do not output the shell name, only the code that is valid {shell_name}. 
         Condense the code into a single line such that it can be ran in the terminal.
         """
 
-        # TODO potentially sanitize this further heuristically?
         result = gpt_query(prompt, text_to_process)
         return result
 

--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -69,7 +69,7 @@ class UserActions:
 
         prompt = f"""
         Generate a {shell_name} shell command that will perform the given task.
-        Only include the code. Do not include any comments, backticks, or natural language explanations. Do not output the shell name, only the code that is valid {shell_name}. 
+        Only include the code. Do not include any comments, backticks, or natural language explanations. Do not output the shell name, only the code that is valid {shell_name}.
         Condense the code into a single line such that it can be ran in the terminal.
         """
 

--- a/lib/talonSettings.py
+++ b/lib/talonSettings.py
@@ -29,12 +29,17 @@ mod.setting(
 mod.setting(
     "model_system_prompt",
     type=str,
-    default="You are an assistant helping an office worker to be more productive. Output just the response to the request and no additional content. Do not generate any markdown formatting unless it is requested.",
+    default="You are an assistant helping an office worker to be more productive. Output just the response to the request and no additional content. Do not generate any markdown formatting such as backticks for programming languages unless it is explicitly requested.",
     desc="The default system prompt that informs the way the model should behave at a high level",
 )
 
+mod.setting("model_shell_default", 
+            type=str,
+            default="bash",
+            desc="The default shell for outputting model shell commands"
+            )
 
+# Image description settings
 mod.setting("openDescriptionInBrowser", type=bool, default=True)
 mod.setting("maxDescriptionTokens", type=int, default=300)
-
 mod.list("descriptionPrompt", desc="Prompts for describing images")

--- a/lib/talonSettings.py
+++ b/lib/talonSettings.py
@@ -33,11 +33,12 @@ mod.setting(
     desc="The default system prompt that informs the way the model should behave at a high level",
 )
 
-mod.setting("model_shell_default", 
-            type=str,
-            default="bash",
-            desc="The default shell for outputting model shell commands"
-            )
+mod.setting(
+    "model_shell_default",
+    type=str,
+    default="bash",
+    desc="The default shell for outputting model shell commands",
+)
 
 # Image description settings
 mod.setting("openDescriptionInBrowser", type=bool, default=True)


### PR DESCRIPTION
Supports a setting to specify the shell name. 

@jaresty let me know if this is what you want. Nushell probably will not work particularly well since the model has less context for it. But GPT 4 might work better.

Either way this is a useful setting since I sometimes I need powershell if my terminal is windows terminal instead of my usual Linux setup