### PR TITLE
don't try to use ~/Downloads if it doesn't exist

### DIFF
--- a/lib/HTMLBuilder.py
+++ b/lib/HTMLBuilder.py
@@ -127,10 +127,11 @@ class Builder:
 
         # If you are using a browser through a snap package on Linux you cannot
         # open many directories so we just default to the downloads folder since that is one we can use
+        dir = None
         if platform.system() == "Linux":
-            dir = os.path.join(os.path.expanduser("~"), "Downloads")
-        else:
-            dir = None
+            default = os.path.join(os.path.expanduser("~"), "Downloads")
+            if os.path.exists(default):
+                dir = default
 
         with tempfile.NamedTemporaryFile(
             mode="w+", suffix=".html", delete=False, encoding="utf-8", dir=dir


### PR DESCRIPTION
ATM things like `model help` fail if `~/Downloads` doesn't exist, so this fixes things to just use `/tmp` if `~/Downloads` doesn't exist. For snaps, which I don't use, I'm not sure how they deal with that folder not existing. Perhaps they use `/etc/xdg/user-dirs.defaults`, but not worth getting too fancy until it's needed.