### PR TITLE
Cleanup model blend cursorless grammar

### DIFF
--- a/GPT/beta-commands/beta-cursorless.talon
+++ b/GPT/beta-commands/beta-cursorless.talon
@@ -20,7 +20,7 @@ model blend <user.cursorless_target> to <user.cursorless_target>:
     result = user.gpt_blend_list(target_text, destination_text)
     user.cursorless_insert(default_destination, result)
 
-model blend clip to <user.cursorless_target>:
+model (blend clip | paste) to <user.cursorless_target>:
     clipboard_text = clip.text()
     destination_text = user.cursorless_get_text(cursorless_target)
     default_destination = user.cursorless_create_destination(cursorless_target)

--- a/GPT/beta-commands/beta-cursorless.talon
+++ b/GPT/beta-commands/beta-cursorless.talon
@@ -21,8 +21,8 @@ model blend <user.cursorless_target> to <user.cursorless_target>:
     user.cursorless_insert(default_destination, result)
 
 model blend clip to <user.cursorless_target>:
-    target_text = edit.selected_text()
+    clipboard_text = clip.text()
     destination_text = user.cursorless_get_text(cursorless_target)
     default_destination = user.cursorless_create_destination(cursorless_target)
-    result = user.gpt_blend(target_text, destination_text)
+    result = user.gpt_blend(clipboard_text, destination_text)
     user.cursorless_insert(default_destination, result)

--- a/GPT/beta-commands/beta-cursorless.talon
+++ b/GPT/beta-commands/beta-cursorless.talon
@@ -20,7 +20,7 @@ model blend <user.cursorless_target> to <user.cursorless_target>:
     result = user.gpt_blend_list(target_text, destination_text)
     user.cursorless_insert(default_destination, result)
 
-model (blend clip | paste) to <user.cursorless_target>:
+model blend clip to <user.cursorless_target>:
     clipboard_text = clip.text()
     destination_text = user.cursorless_get_text(cursorless_target)
     default_destination = user.cursorless_create_destination(cursorless_target)

--- a/GPT/beta-commands/beta-cursorless.talon
+++ b/GPT/beta-commands/beta-cursorless.talon
@@ -20,14 +20,9 @@ model blend <user.cursorless_target> to <user.cursorless_target>:
     result = user.gpt_blend_list(target_text, destination_text)
     user.cursorless_insert(default_destination, result)
 
-model blend to <user.cursorless_target>:
+model blend clip to <user.cursorless_target>:
     target_text = edit.selected_text()
     destination_text = user.cursorless_get_text(cursorless_target)
     default_destination = user.cursorless_create_destination(cursorless_target)
     result = user.gpt_blend(target_text, destination_text)
     user.cursorless_insert(default_destination, result)
-
-model blend <user.cursorless_target>:
-    target_text = user.cursorless_get_text_list(cursorless_target)
-    result = user.gpt_blend_list(target_text, edit.selected_text())
-    user.paste(result)

--- a/GPT/beta-commands/beta-gpt.talon
+++ b/GPT/beta-commands/beta-gpt.talon
@@ -6,7 +6,7 @@ tag: user.gpt_beta
 model find <user.text>: user.gpt_find_talon_commands(user.text)
 
 # Using the context of the text on the clipboard, update the selected text
-model blend clipboard:
+model blend clip:
     clipboard_text = clip.text()
     destination_text = edit.selected_text()
     result = user.gpt_blend(clipboard_text, destination_text)


### PR DESCRIPTION
- Model blend to <target> didn't specify a source; now it specifies the source as clipboard
- Model blend <target> was only implicitly dropping the 'this'
