### PR TITLE
Revert cursorless gpt

### DIFF
--- a/GPT/gpt-cursorless.talon
+++ b/GPT/gpt-cursorless.talon
@@ -1,6 +1,5 @@
 mode: command
 tag: user.cursorless
-
 -
 
 # Apply a prompt to any text, and output it any target

--- a/GPT/gpt-cursorless.talon
+++ b/GPT/gpt-cursorless.talon
@@ -1,0 +1,12 @@
+mode: command
+tag: user.cursorless
+
+-
+
+# Apply a prompt to any text, and output it any target
+# Paste it to the cursor if no target is specified
+model <user.modelPrompt> <user.cursorless_target> [<user.cursorless_destination>]$:
+    text = user.cursorless_get_text_list(cursorless_target)
+    result = user.gpt_apply_prompt(user.modelPrompt, text)
+    default_destination = user.cursorless_create_destination(cursorless_target)
+    user.cursorless_insert(cursorless_destination or default_destination, result)


### PR DESCRIPTION
The long term goal for this repo is to have one single grammar for the entire pipeline. Currently it is difficult to fit cursorless in that due to the fact that it increases DFA compilation times for Talon and it is occasionally too verbose/increaes cognitive load. However, it is still quite useful, so adding it back for the time being until there is a better plan for how to put this in the pipeline