### PR TITLE
snippet refactor

### DIFF
--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -153,11 +153,10 @@ class UserActions:
             else text_to_process
         )
 
-
         """
         Handle special prompts that require arbitrary text.
 
-        These prompts treat <user.text> as the source by setting 
+        These prompts treat <user.text> as the source by setting
         text_to_process to the natural language request.
         """
 

--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -153,11 +153,21 @@ class UserActions:
             else text_to_process
         )
 
-        # Ask is a special case, where the text to process is the prompted question, not the selected text
+
+        """
+        Handle special prompts that require arbitrary text.
+
+        These prompts treat <user.text> as the source by setting 
+        text_to_process to the natural language request.
+        """
+
         if prompt.startswith("ask"):
             text_to_process = prompt.removeprefix("ask")
             prompt = """Generate text that satisfies the question or request given in the input."""
         # If the user is just moving the source to the destination, we don't need to apply a query
+        elif prompt.startswith("snip"):
+            text_to_process = prompt.removeprefix("snip")
+            prompt = "Please return the response as a textmate snippet for insertion into an editor with placeholders that the user should edit. Return just the snippet content - no XML and no heading."
         elif prompt == "pass":
             return text_to_process
 
@@ -220,8 +230,6 @@ class UserActions:
                     actions.user.tts(result)
                 except KeyError:
                     notify("GPT Failure: text to speech is not installed")
-            # Although we can insert to a cursorless dpestination, the cursorless_target capture
-            # Greatly increases DFA compliation times and should be avoided if possible
             case "cursorless":
                 actions.user.cursorless_insert(cursorless_destination, result)
             case "paste" | _:

--- a/lib/talonSettings.py
+++ b/lib/talonSettings.py
@@ -16,7 +16,7 @@ mod.list("modelSource", desc="Where to get the text from for the GPT")
 
 # model prompts can be either static and predefined by this repo or custom outside of it
 @mod.capture(
-    rule="{user.staticPrompt} | {user.customPrompt} | (please <user.text>) | (ask <user.text>) | pass"
+    rule="{user.staticPrompt} | {user.customPrompt} | (please <user.text>) | (ask <user.text>) | snip <user.text> | pass"
 )
 def modelPrompt(matched_prompt) -> str:
     return str(matched_prompt)
@@ -39,6 +39,7 @@ mod.setting(
     default="https://api.openai.com/v1/chat/completions",
     desc="The endpoint to send the model requests to",
 )
+
 
 mod.setting(
     "model_system_prompt",


### PR DESCRIPTION
@jaresty made some changes to support snippets in a new PR

-  I think `snip` should be a prompt, not an insertion modifier. 
`model snip generate a pandas dataclass` or `model snip generate a class`

- I think we shouldn't really have an insertion modifier list since it adds more complexity
   -  My number one goal is to improve discoverability right now. I think this hurts that. 
- Kept some things that were removed in the other PR that I mentioned in my last comment.

In general I also am not clear how to use this. How do you have it insert a snippet like talon inserts snippets where you can jump between sections? I don't find the prompt performs that well but maybe I am doing something wrong