### PR TITLE
Alternative snippet refactor

### DIFF
--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -199,12 +199,12 @@ class UserActions:
             case "above":
                 actions.key("left")
                 actions.edit.line_insert_up()
-                actions.user.paste(result)
+                actions.user.insert_snippet(result)
                 GPTState.last_was_pasted = True
             case "below":
                 actions.key("right")
                 actions.edit.line_insert_down()
-                actions.user.paste(result)
+                actions.user.insert_snippet(result)
                 GPTState.last_was_pasted = True
             case "clipboard":
                 clip.set_text(result)
@@ -226,7 +226,7 @@ class UserActions:
             case "cursorless":
                 actions.user.cursorless_insert(cursorless_destination, result)
             case "paste" | _:
-                actions.user.paste(result)
+                actions.user.insert_snippet(result)
                 GPTState.last_was_pasted = True
 
     def gpt_get_source_text(spoken_text: str) -> str:

--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -191,20 +191,31 @@ class UserActions:
             notify("No text to reformat")
             raise Exception("No text to reformat")
 
+    def paste_or_snippet(result: str, is_snippet: bool):
+        """Paste or insert the result of a GPT query as a snippet"""
+        if is_snippet:
+            actions.user.insert_snippet(result)
+        else:
+            actions.user.paste(result)
+
     def gpt_insert_response(
-        result: str, method: str = "", cursorless_destination: Any = None
+        result: str,
+        prompt: str = "",
+        method: str = "",
+        cursorless_destination: Any = None,
     ):
         """Insert a GPT result in a specified way"""
+        is_snippet = prompt.startswith("snip")
         match method:
             case "above":
                 actions.key("left")
                 actions.edit.line_insert_up()
-                actions.user.insert_snippet(result)
+                actions.user.paste_or_snippet(result, is_snippet)
                 GPTState.last_was_pasted = True
             case "below":
                 actions.key("right")
                 actions.edit.line_insert_down()
-                actions.user.insert_snippet(result)
+                actions.user.paste_or_snippet(result, is_snippet)
                 GPTState.last_was_pasted = True
             case "clipboard":
                 clip.set_text(result)
@@ -226,7 +237,7 @@ class UserActions:
             case "cursorless":
                 actions.user.cursorless_insert(cursorless_destination, result)
             case "paste" | _:
-                actions.user.insert_snippet(result)
+                actions.user.paste_or_snippet(result, is_snippet)
                 GPTState.last_was_pasted = True
 
     def gpt_get_source_text(spoken_text: str) -> str:

--- a/GPT/gpt.talon
+++ b/GPT/gpt.talon
@@ -8,7 +8,7 @@ model help$: user.gpt_help()
 model <user.modelPrompt> [{user.modelSource}] [{user.modelDestination}]:
     text = user.gpt_get_source_text(modelSource or "")
     result = user.gpt_apply_prompt(modelPrompt, text)
-    user.gpt_insert_response(result, modelDestination or "")
+    user.gpt_insert_response(result, modelPrompt, modelDestination or "")
 
 # Select the last GPT response so you can edit it further
 model take response: user.gpt_select_last()

--- a/GPT/lists/staticPrompt.talon-list
+++ b/GPT/lists/staticPrompt.talon-list
@@ -43,4 +43,3 @@ translate to english: Translate the following text into English.
 ## CODE GENERATION
 generate code: the following plaintext describes a process in code in the language that is specified by the system prompt. Please output the code necessary to do this.
 snip: Make a textmate snippet for insertion into an editor with placeholders that the user should edit. Return just the snippet content - no XML and no heading.
-

--- a/GPT/lists/staticPrompt.talon-list
+++ b/GPT/lists/staticPrompt.talon-list
@@ -42,4 +42,4 @@ translate to english: Translate the following text into English.
 
 ## CODE GENERATION
 generate code: the following plaintext describes a process in code in the language that is specified by the system prompt. Please output the code necessary to do this.
-snip: Make a textmate snippet for insertion into an editor with placeholders that the user should edit. Return just the snippet content - no XML and no heading.
+snip: snip - Make a textmate snippet for insertion into an editor with placeholders that the user should edit. Return just the snippet content - no XML and no heading.

--- a/GPT/lists/staticPrompt.talon-list
+++ b/GPT/lists/staticPrompt.talon-list
@@ -42,3 +42,5 @@ translate to english: Translate the following text into English.
 
 ## CODE GENERATION
 generate code: the following plaintext describes a process in code in the language that is specified by the system prompt. Please output the code necessary to do this.
+snip: Make a textmate snippet for insertion into an editor with placeholders that the user should edit. Return just the snippet content - no XML and no heading.
+


### PR DESCRIPTION
- This make snippet just like any other prompt
- you can run it on the clipboard or on selected text
- If we someday get around to adding the ability to pass additional context to every prompt, snippets would get it as well