### PR TITLE
Baseline refactoring to prepare for cleanups

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,4 @@
         "editor.defaultFormatter": "charliermarsh.ruff"
     },
     "python.analysis.typeCheckingMode": "standard"
-    
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,7 @@
             "source.fixAll": "always"
         },
         "editor.defaultFormatter": "charliermarsh.ruff"
-    }
+    },
+    "python.analysis.typeCheckingMode": "standard"
+    
 }

--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -1,10 +1,11 @@
 import os
-from typing import Any, ClassVar
+from typing import Any
 
-from talon import Module, actions, clip, imgui, settings
+from talon import Module, actions, clip, settings
 
 from ..lib.HTMLBuilder import Builder
 from ..lib.modelHelpers import (
+    GPTState,
     clear_context,
     extract_message,
     format_clipboard,
@@ -21,32 +22,6 @@ from ..lib.modelHelpers import (
 )
 
 mod = Module()
-
-
-class GPTState:
-    text_to_confirm: ClassVar[str] = ""
-    last_response: ClassVar[str] = ""
-    last_was_pasted: ClassVar[bool] = False
-
-
-@imgui.open()
-def confirmation_gui(gui: imgui.GUI):
-    gui.text("Confirm model output before pasting")
-    gui.line()
-    gui.spacer()
-    gui.text(GPTState.text_to_confirm)
-
-    gui.spacer()
-    if gui.button("Paste model output"):
-        actions.user.paste_model_confirmation_gui()
-
-    gui.spacer()
-    if gui.button("Copy model output"):
-        actions.user.copy_model_confirmation_gui()
-
-    gui.spacer()
-    if gui.button("Deny model output"):
-        actions.user.close_model_confirmation_gui()
 
 
 def gpt_query(prompt: dict[str, any], content: dict[str, any], modifier: str = ""):
@@ -117,11 +92,6 @@ class UserActions:
             "text"
         ]
 
-    def add_to_confirmation_gui(model_output: str):
-        """Add text to the confirmation gui"""
-        GPTState.text_to_confirm = model_output
-        confirmation_gui.show()
-
     def gpt_clear_context():
         """Reset the stored context"""
         clear_context()
@@ -149,24 +119,6 @@ class UserActions:
     def contextual_user_context():
         """This is an override function that can be used to add additional context to the prompt"""
         return []
-
-    def close_model_confirmation_gui():
-        """Close the model output without pasting it"""
-        GPTState.text_to_confirm = ""
-        confirmation_gui.hide()
-
-    def copy_model_confirmation_gui():
-        """Copy the model output to the clipboard"""
-        clip.set_text(GPTState.text_to_confirm)
-        GPTState.text_to_confirm = ""
-
-        confirmation_gui.hide()
-
-    def paste_model_confirmation_gui():
-        """Paste the model output"""
-        actions.user.paste(GPTState.text_to_confirm)
-        GPTState.text_to_confirm = ""
-        confirmation_gui.hide()
 
     def gpt_select_last():
         """select all the text in the last GPT output"""

--- a/lib/a11yHelpers.py
+++ b/lib/a11yHelpers.py
@@ -2,7 +2,6 @@
 # https://github.com/phillco/talon-axkit/blob/main/dictation/dictation_context.py
 
 from talon import Context, Module, ui
-from talon.types import Span
 
 ctx = Context()
 ctx.matches = r"""

--- a/lib/modelConfirmationGUI.py
+++ b/lib/modelConfirmationGUI.py
@@ -1,0 +1,51 @@
+from .modelHelpers import GPTState
+from talon import imgui, actions, Module, clip
+
+
+mod = Module()
+
+
+@imgui.open()
+def confirmation_gui(gui: imgui.GUI):
+    gui.text("Confirm model output before pasting")
+    gui.line()
+    gui.spacer()
+    gui.text(GPTState.text_to_confirm)
+
+    gui.spacer()
+    if gui.button("Paste model output"):
+        actions.user.paste_model_confirmation_gui()
+
+    gui.spacer()
+    if gui.button("Copy model output"):
+        actions.user.copy_model_confirmation_gui()
+
+    gui.spacer()
+    if gui.button("Deny model output"):
+        actions.user.close_model_confirmation_gui()
+
+
+@mod.action_class
+class UserActions:
+    def add_to_confirmation_gui(model_output: str):
+        """Add text to the confirmation gui"""
+        GPTState.text_to_confirm = model_output
+        confirmation_gui.show()
+
+    def close_model_confirmation_gui():
+        """Close the model output without pasting it"""
+        GPTState.text_to_confirm = ""
+        confirmation_gui.hide()
+
+    def copy_model_confirmation_gui():
+        """Copy the model output to the clipboard"""
+        clip.set_text(GPTState.text_to_confirm)
+        GPTState.text_to_confirm = ""
+
+        confirmation_gui.hide()
+
+    def paste_model_confirmation_gui():
+        """Paste the model output"""
+        actions.user.paste(GPTState.text_to_confirm)
+        GPTState.text_to_confirm = ""
+        confirmation_gui.hide()

--- a/lib/modelConfirmationGUI.py
+++ b/lib/modelConfirmationGUI.py
@@ -1,6 +1,6 @@
-from .modelHelpers import GPTState
-from talon import imgui, actions, Module, clip
+from talon import Module, actions, clip, imgui
 
+from .modelHelpers import GPTState
 
 mod = Module()
 

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import os
-from typing import Optional, Tuple
+from typing import ClassVar, Optional, Tuple
 
 import requests
 from talon import actions, app, clip, settings
@@ -12,6 +12,12 @@ from .modelTypes import Data, Headers, Tool
 """"
 All functions in this this file have impure dependencies on either the model or the talon APIs
 """
+
+
+class GPTState:
+    text_to_confirm: ClassVar[str] = ""
+    last_response: ClassVar[str] = ""
+    last_was_pasted: ClassVar[bool] = False
 
 
 stored_context = []

--- a/lib/modelTypes.py
+++ b/lib/modelTypes.py
@@ -16,12 +16,6 @@ class GPTMessage:
         self.content = content
         self.type = type
 
-    def __str__(self):
-        return self.content
-
-    def to_string(self):
-        return str(self)
-
     def to_dict(self):
         return {
             "type": self.type,

--- a/lib/modelTypes.py
+++ b/lib/modelTypes.py
@@ -1,5 +1,35 @@
 import enum
-from typing import Optional, TypedDict
+from typing import Literal, Optional, TypedDict
+
+
+class MessageRole(enum.Enum):
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+
+
+class GPTMessage:
+    type: Literal["text", "image_url"]
+    content: str
+
+    def __init__(self, content: str, type: Literal["text", "image_url"] = "text"):
+        self.content = content
+        self.type = type
+
+    def __str__(self):
+        return self.content
+
+    def to_string(self):
+        return str(self)
+
+    def to_dict(self):
+        return {
+            "type": self.type,
+            "content": self.content,
+        }
+
+    def get_content(self):
+        return self.content
 
 
 class FunctionArguments(TypedDict):


### PR DESCRIPTION
Doesn't change any behavior, just prepares the codebase a bit by moving a few things to new files and beginning to add a new class for a generic GPTMessage. I need to experiment with how we will use this with images and context. 

Instead of passing things through, now that we have one larger function, we can just set a state variable at the start, check it right before the query, and then reset it at the end of the query. I think this might be easier and we don't need to pass things around. Will explore this later.