### PR TITLE
Use a better state class; more general refactor work

### DIFF
--- a/GPT/gpt-contextual.talon
+++ b/GPT/gpt-contextual.talon
@@ -1,0 +1,6 @@
+# Clear the context stored in the model
+model context clear: user.gpt_clear_context()
+
+# Create a new thread which is similar to a conversation with the model
+# A thread allows the model to access data from the previous queries in the same thread
+model thread new: user.gpt_new_thread()

--- a/GPT/gpt-contextual.talon
+++ b/GPT/gpt-contextual.talon
@@ -1,6 +1,0 @@
-# Clear the context stored in the model
-model context clear: user.gpt_clear_context()
-
-# Create a new thread which is similar to a conversation with the model
-# A thread allows the model to access data from the previous queries in the same thread
-model thread new: user.gpt_new_thread()

--- a/GPT/gpt.talon
+++ b/GPT/gpt.talon
@@ -23,3 +23,10 @@ model apply [from] clip$:
 model [nope] that was <user.text>$:
     result = user.gpt_reformat_last(text)
     user.paste(result)
+
+# Clear the context stored in the model
+model context clear: user.gpt_clear_context()
+
+# Create a new thread which is similar to a conversation with the model
+# A thread allows the model to access data from the previous queries in the same thread
+model thread new: user.gpt_new_thread()

--- a/GPT/gpt.talon
+++ b/GPT/gpt.talon
@@ -6,7 +6,7 @@ model help$: user.gpt_help()
 #   Example: `model explain this` -> Explains the selected text and pastes in place
 #   Example: `model fix grammar clip to browser` -> Fixes the grammar of the text on the clipboard and opens in browser`
 model [{user.modelModifier}] <user.modelPrompt> [{user.modelSource}] [{user.modelDestination}]:
-    user.gpt_apply_prompt(modelModifier or "normal", modelPrompt, modelSource or "", modelDestination or "")
+    user.gpt_apply_prompt(modelPrompt, modelSource or "", modelDestination or "", modelModifier or "")
 
 # Select the last GPT response so you can edit it further
 model take response: user.gpt_select_last()
@@ -23,10 +23,3 @@ model apply [from] clip$:
 model [nope] that was <user.text>$:
     result = user.gpt_reformat_last(text)
     user.paste(result)
-
-# Clear the context stored in the model
-model context clear: user.gpt_clear_context()
-
-# Create a new thread which is similar to a conversation with the model
-# A thread allows the model to access data from the previous queries in the same thread
-model thread new: user.gpt_new_thread()

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -7,8 +7,8 @@ import requests
 from talon import actions, app, clip, settings
 
 from ..lib.pureHelpers import strip_markdown
-from .modelTypes import Data, Headers, Tool
 from .modelState import GPTState
+from .modelTypes import Data, Headers, Tool
 
 """"
 All functions in this this file have impure dependencies on either the model or the talon APIs

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -1,55 +1,18 @@
 import base64
 import json
 import os
-from typing import ClassVar, Optional, Tuple
+from typing import Optional, Tuple
 
 import requests
 from talon import actions, app, clip, settings
 
 from ..lib.pureHelpers import strip_markdown
 from .modelTypes import Data, Headers, Tool
+from .modelState import GPTState
 
 """"
 All functions in this this file have impure dependencies on either the model or the talon APIs
 """
-
-
-class GPTState:
-    text_to_confirm: ClassVar[str] = ""
-    last_response: ClassVar[str] = ""
-    last_was_pasted: ClassVar[bool] = False
-
-
-stored_context = []
-thread_context = []
-
-
-def clear_context():
-    """Reset the stored context"""
-    global stored_context
-    stored_context = []
-    actions.app.notify("Cleared user context")
-
-
-def new_thread():
-    """Create a new thread"""
-    global thread_context
-    thread_context = []
-    actions.app.notify("Created a new thread")
-
-
-def push_context(context: dict[str, any]):
-    """Add the selected text to the stored context"""
-    global stored_context
-    stored_context += [context]
-    actions.app.notify("Appended user context")
-
-
-def push_thread(context: dict[str, any]):
-    """Add the selected text to the current thread"""
-    global thread_context
-    thread_context += [context]
-    actions.app.notify("Appended to thread")
 
 
 def messages_to_string(messages: list[dict[str, any]]) -> str:
@@ -61,18 +24,6 @@ def messages_to_string(messages: list[dict[str, any]]) -> str:
         else:
             formatted_messages.append(message.get("text", ""))
     return "\n\n".join(formatted_messages)
-
-
-def string_context():
-    """Format the context for display"""
-    global stored_context
-    return messages_to_string(stored_context)
-
-
-def string_thread():
-    """Format the thread for display"""
-    global thread_context
-    return messages_to_string(thread_context)
 
 
 def gpt_send_request(headers: Headers, data: Data):
@@ -151,10 +102,8 @@ def generate_payload(
     """Generate the headers and data for the OpenAI API GPT request.
     Does not return the URL given the fact not all openai-compatible endpoints support new features like tools
     """
-    global stored_context
-    global thread_context
     notification = "GPT Task Started"
-    if len(stored_context) > 0:
+    if len(GPTState.context) > 0:
         notification += ": Reusing Stored Context"
     notify(notification)
     TOKEN = get_token()
@@ -175,9 +124,9 @@ def generate_payload(
             + f"The following describes the currently focused application:\n\n{actions.user.talon_get_active_context()}"
         ]
     ]
-    reused_context = stored_context
+    reused_context = GPTState.context
     if modifier == "thread":
-        reused_context += thread_context
+        reused_context += GPTState.thread
 
     current_query = [prompt]
     if content != "__CONTEXT__":

--- a/lib/modelState.py
+++ b/lib/modelState.py
@@ -1,0 +1,42 @@
+from talon import actions
+from typing import ClassVar
+
+
+class GPTState:
+    text_to_confirm: ClassVar[str] = ""
+    last_response: ClassVar[str] = ""
+    last_was_pasted: ClassVar[bool] = False
+    context: ClassVar[list] = []
+    thread: ClassVar[list] = []
+
+    @classmethod
+    def clear_context(cls):
+        """Reset the stored context"""
+        cls.context = []
+        actions.app.notify("Cleared user context")
+
+    @classmethod
+    def new_thread(cls):
+        """Create a new thread"""
+        cls.thread = []
+        actions.app.notify("Created a new thread")
+
+    @classmethod
+    def push_context(cls, context: dict[str, any]):
+        """Add the selected text to the stored context"""
+        cls.context += [context]
+        actions.app.notify("Appended user context")
+
+    @classmethod
+    def push_thread(cls, context: dict[str, any]):
+        """Add the selected text to the current thread"""
+        cls.thread += [context]
+        actions.app.notify("Appended to thread")
+
+    @classmethod
+    def reset_all(cls):
+        cls.text_to_confirm = ""
+        cls.last_response = ""
+        cls.last_was_pasted = False
+        cls.context = []
+        cls.thread = []

--- a/lib/modelState.py
+++ b/lib/modelState.py
@@ -1,5 +1,6 @@
-from talon import actions
 from typing import ClassVar
+
+from talon import actions
 
 
 class GPTState:


### PR DESCRIPTION
Changes the code to use a central state class instead of global variables. This makes the code cleaner and easier to extend.

Any methods dealing with state like threading or contact we want to put within this class to separate from pure functions or talon user facing code.

Cleaned up a few other things. gpt.talon included "normal" as the default but "normal" was not being checked anywhere. So just used "" instead. 

Don't believe this causes any regressions and is just a refactor.