### PR TITLE
Adjust verbosity of model window commands

### DIFF
--- a/GPT/gpt-shell.talon
+++ b/GPT/gpt-shell.talon
@@ -12,9 +12,13 @@ model (sequel | sql) <user.text>$:
     user.add_to_confirmation_gui(result)
 
 # Confirm and paste the output of the model
-^model paste output$: user.paste_model_confirmation_gui()
+^paste response$: user.paste_model_confirmation_gui()
 
-^model copy output$: user.copy_model_confirmation_gui()
+# Confirm and paste the output of the model selected
+^chain response$:
+    user.chain_model_confirmation_gui()
+
+^copy response$: user.copy_model_confirmation_gui()
 
 # Deny the output of the model and discard it
-^model discard output$: user.close_model_confirmation_gui()
+^discard response$: user.close_model_confirmation_gui()

--- a/GPT/gpt-shell.talon
+++ b/GPT/gpt-shell.talon
@@ -15,8 +15,7 @@ model (sequel | sql) <user.text>$:
 ^paste response$: user.paste_model_confirmation_gui()
 
 # Confirm and paste the output of the model selected
-^chain response$:
-    user.chain_model_confirmation_gui()
+^chain response$: user.chain_model_confirmation_gui()
 
 ^copy response$: user.copy_model_confirmation_gui()
 

--- a/GPT/gpt-shell.talon
+++ b/GPT/gpt-shell.talon
@@ -10,14 +10,3 @@ model shell <user.text>$:
 model (sequel | sql) <user.text>$:
     result = user.gpt_generate_sql(user.text)
     user.add_to_confirmation_gui(result)
-
-# Confirm and paste the output of the model
-^paste response$: user.paste_model_confirmation_gui()
-
-# Confirm and paste the output of the model selected
-^chain response$: user.chain_model_confirmation_gui()
-
-^copy response$: user.copy_model_confirmation_gui()
-
-# Deny the output of the model and discard it
-^discard response$: user.close_model_confirmation_gui()

--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -17,6 +17,10 @@ from ..lib.modelHelpers import (
 from ..lib.modelState import GPTState
 
 mod = Module()
+mod.tag(
+    "model_window_open",
+    desc="Tag for enabling the model window commands when the window is open",
+)
 
 
 def gpt_query(prompt: dict[str, any], content: dict[str, any], modifier: str = ""):

--- a/GPT/model-window-open.talon
+++ b/GPT/model-window-open.talon
@@ -10,6 +10,8 @@ tag: user.model_window_open
     user.gpt_select_last()
 
 ^copy response$: user.copy_model_confirmation_gui()
+^pass response to context$: user.pass_context_model_confirmation_gui()
+^pass response to thread$: user.pass_thread_model_confirmation_gui()
 
 # Deny the output of the model and discard it
 ^discard response$: user.close_model_confirmation_gui()

--- a/GPT/model-window-open.talon
+++ b/GPT/model-window-open.talon
@@ -1,0 +1,15 @@
+tag: user.model_window_open
+-
+
+# Confirm and paste the output of the model
+^paste response$: user.paste_model_confirmation_gui()
+
+# Confirm and paste the output of the model selected
+^chain response$:
+    user.paste_model_confirmation_gui()
+    user.gpt_select_last()
+
+^copy response$: user.copy_model_confirmation_gui()
+
+# Deny the output of the model and discard it
+^discard response$: user.close_model_confirmation_gui()

--- a/lib/modelConfirmationGUI.py
+++ b/lib/modelConfirmationGUI.py
@@ -24,6 +24,14 @@ def confirmation_gui(gui: imgui.GUI):
         actions.user.gpt_select_last()
 
     gui.spacer()
+    if gui.button("Pass response to context"):
+        actions.user.pass_context_model_confirmation_gui()
+
+    gui.spacer()
+    if gui.button("Pass response to thread"):
+        actions.user.pass_thread_model_confirmation_gui()
+
+    gui.spacer()
     if gui.button("Copy response"):
         actions.user.copy_model_confirmation_gui()
 
@@ -45,6 +53,18 @@ class UserActions:
         GPTState.text_to_confirm = ""
         confirmation_gui.hide()
         ctx.tags = []
+
+    def pass_context_model_confirmation_gui():
+        """Add the model output to the context"""
+        actions.user.gpt_push_context(GPTState.text_to_confirm)
+        GPTState.text_to_confirm = ""
+        actions.user.close_model_confirmation_gui()
+
+    def pass_thread_model_confirmation_gui():
+        """Add the model output to the thread"""
+        actions.user.gpt_push_thread(GPTState.text_to_confirm)
+        GPTState.text_to_confirm = ""
+        actions.user.close_model_confirmation_gui()
 
     def copy_model_confirmation_gui():
         """Copy the model output to the clipboard"""

--- a/lib/modelConfirmationGUI.py
+++ b/lib/modelConfirmationGUI.py
@@ -1,4 +1,4 @@
-from talon import Module, Context, actions, clip, imgui
+from talon import Context, Module, actions, clip, imgui
 
 from .modelHelpers import GPTState, notify
 

--- a/lib/modelConfirmationGUI.py
+++ b/lib/modelConfirmationGUI.py
@@ -14,15 +14,20 @@ def confirmation_gui(gui: imgui.GUI):
         gui.text(line)
 
     gui.spacer()
-    if gui.button("Model paste output"):
+    if gui.button("Paste response"):
         actions.user.paste_model_confirmation_gui()
 
     gui.spacer()
-    if gui.button("Model copy output"):
+    if gui.button("Chain response"):
+        actions.user.paste_model_confirmation_gui()
+        actions.user.gpt_select_last()
+
+    gui.spacer()
+    if gui.button("Copy response"):
         actions.user.copy_model_confirmation_gui()
 
     gui.spacer()
-    if gui.button("Model discard output"):
+    if gui.button("Discard response"):
         actions.user.close_model_confirmation_gui()
 
 
@@ -54,5 +59,12 @@ class UserActions:
             return
         else:
             actions.user.paste(GPTState.text_to_confirm)
+            GPTState.last_response = GPTState.text_to_confirm
+            GPTState.last_was_pasted = True
             GPTState.text_to_confirm = ""
             confirmation_gui.hide()
+
+    def chain_model_confirmation_gui():
+        """Chain the model output"""
+        actions.user.paste_model_confirmation_gui()
+        actions.user.gpt_select_last()

--- a/lib/modelConfirmationGUI.py
+++ b/lib/modelConfirmationGUI.py
@@ -41,7 +41,7 @@ class UserActions:
         confirmation_gui.show()
 
     def close_model_confirmation_gui():
-        """Close the model output without pasting itp"""
+        """Close the model output without pasting it"""
         GPTState.text_to_confirm = ""
         confirmation_gui.hide()
         ctx.tags = []

--- a/lib/modelConfirmationGUI.py
+++ b/lib/modelConfirmationGUI.py
@@ -1,8 +1,9 @@
-from talon import Module, actions, clip, imgui
+from talon import Module, Context, actions, clip, imgui
 
 from .modelHelpers import GPTState, notify
 
 mod = Module()
+ctx = Context()
 
 
 @imgui.open()
@@ -35,36 +36,33 @@ def confirmation_gui(gui: imgui.GUI):
 class UserActions:
     def add_to_confirmation_gui(model_output: str):
         """Add text to the confirmation gui"""
+        ctx.tags = ["user.model_window_open"]
         GPTState.text_to_confirm = model_output
         confirmation_gui.show()
 
     def close_model_confirmation_gui():
-        """Close the model output without pasting it"""
+        """Close the model output without pasting itp"""
         GPTState.text_to_confirm = ""
         confirmation_gui.hide()
+        ctx.tags = []
 
     def copy_model_confirmation_gui():
-        """Copy the model output to the clipboard"""
+        """Copy the model ctx.tags = ["user.model_window_open"] to the clipboard"""
         clip.set_text(GPTState.text_to_confirm)
         GPTState.text_to_confirm = ""
 
-        confirmation_gui.hide()
+        actions.user.close_model_confirmation_gui()
 
     def paste_model_confirmation_gui():
         """Paste the model output"""
         if not GPTState.text_to_confirm:
             notify("GPT error: No text in confirmation GUI to paste")
             GPTState.text_to_confirm = ""
-            confirmation_gui.hide()
+            actions.user.close_model_confirmation_gui()
             return
         else:
             actions.user.paste(GPTState.text_to_confirm)
             GPTState.last_response = GPTState.text_to_confirm
             GPTState.last_was_pasted = True
             GPTState.text_to_confirm = ""
-            confirmation_gui.hide()
-
-    def chain_model_confirmation_gui():
-        """Chain the model output"""
-        actions.user.paste_model_confirmation_gui()
-        actions.user.gpt_select_last()
+            actions.user.close_model_confirmation_gui()

--- a/lib/modelConfirmationGUI.py
+++ b/lib/modelConfirmationGUI.py
@@ -47,7 +47,7 @@ class UserActions:
         ctx.tags = []
 
     def copy_model_confirmation_gui():
-        """Copy the model ctx.tags = ["user.model_window_open"] to the clipboard"""
+        """Copy the model output to the clipboard"""
         clip.set_text(GPTState.text_to_confirm)
         GPTState.text_to_confirm = ""
 


### PR DESCRIPTION
- if you have the model window open, I think that the "model" is implied
- I think it's also useful to add chain to these commands
- This also aligns the naming of the model output from 'model take response' (I think we should use the same name everywhere for the model output/response)