### PR TITLE
Consolidate clear verbiage

### DIFF
--- a/GPT/gpt-cursorless.talon
+++ b/GPT/gpt-cursorless.talon
@@ -29,7 +29,7 @@ model pass <user.cursorless_target> to thread$:
 # Add the text from a cursorless target to a new thread
 model pass <user.cursorless_target> to new thread$:
     text = user.cursorless_get_text(cursorless_target)
-    user.gpt_new_thread()
+    user.gpt_clear_thread()
     user.gpt_push_thread(text)
 
 # Applies an arbitrary prompt from the clipboard to a cursorless target.

--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -95,7 +95,7 @@ class UserActions:
         """Reset the stored context"""
         GPTState.clear_context()
 
-    def gpt_new_thread():
+    def gpt_clear_thread():
         """Create a new thread"""
         GPTState.new_thread()
 

--- a/GPT/gpt.talon
+++ b/GPT/gpt.talon
@@ -25,8 +25,8 @@ model [nope] that was <user.text>$:
     user.paste(result)
 
 # Clear the context stored in the model
-model context clear: user.gpt_clear_context()
+model clear context: user.gpt_clear_context()
 
 # Create a new thread which is similar to a conversation with the model
 # A thread allows the model to access data from the previous queries in the same thread
-model thread new: user.gpt_new_thread()
+model clear thread: user.gpt_clear_thread()


### PR DESCRIPTION
- I was getting confused by the different ways of clearing context and threads
- Most of our model commands have the structure 'model verb'
- It makes sense to introduce a 'model clear' command that operates on both threads and context