### PR TITLE
Make chain into a destination

### DIFF
--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -238,6 +238,11 @@ class UserActions:
             case "window":
                 actions.user.add_to_confirmation_gui(result)
 
+            case "chain":
+                GPTState.last_was_pasted = True
+                paste_and_modify(result, modifier)
+                actions.user.gpt_select_last()
+
             case "paste" | _:
                 GPTState.last_was_pasted = True
                 paste_and_modify(result, modifier)

--- a/GPT/lists/modelDestination.talon-list
+++ b/GPT/lists/modelDestination.talon-list
@@ -38,3 +38,6 @@ to speech: textToSpeech
 
 # Output the result in a talon imgui window
 to window: window
+
+# Select the response after insertion so you can apply subsequent prompts on it
+chain: chain

--- a/GPT/lists/modelModifier.talon-list
+++ b/GPT/lists/modelModifier.talon-list
@@ -6,6 +6,3 @@ snip: snip
 
 # Keep track of the questions and responses as a conversation
 thread: thread
-
-# Select the response after insertion so you can apply subsequent prompts on it
-chain: chain

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -193,7 +193,3 @@ def paste_and_modify(formatted_message: str, modifier: str = ""):
             actions.user.insert_snippet(formatted_message)
         case "" | _:
             actions.user.paste(formatted_message)
-
-    # Snip is mutually exclusive with pasting, but chain can be run additionally after pasting
-    if modifier == "chain":
-        actions.user.gpt_select_last()


### PR DESCRIPTION
- We're trying to simplify the grammar
- This does remove the ability to chain before or after, but we think that is an unlikely usage