### PR TITLE
Removing thread from modifiers

### DIFF
--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -33,7 +33,7 @@ def gpt_query(prompt: dict[str, any], content: dict[str, any], modifier: str = "
 
     response = gpt_send_request(headers, data)
     GPTState.last_response = extract_message(response)
-    if modifier == "thread":
+    if GPTState.thread_enabled:
         GPTState.push_thread(prompt)
         GPTState.push_thread(content)
         GPTState.push_thread(response)
@@ -98,6 +98,14 @@ class UserActions:
     def gpt_new_thread():
         """Create a new thread"""
         GPTState.new_thread()
+
+    def gpt_enable_threading():
+        """Enable threading of subsequent requests"""
+        GPTState.enable_thread()
+
+    def gpt_disable_threading():
+        """Enable threading of subsequent requests"""
+        GPTState.disable_thread()
 
     def gpt_push_context(context: str):
         """Add the selected text to the stored context"""

--- a/GPT/gpt.talon
+++ b/GPT/gpt.talon
@@ -30,3 +30,6 @@ model context clear: user.gpt_clear_context()
 # Create a new thread which is similar to a conversation with the model
 # A thread allows the model to access data from the previous queries in the same thread
 model thread new: user.gpt_new_thread()
+
+model enable thread: user.gpt_enable_threading()
+model disable thread: user.gpt_disable_threading()

--- a/GPT/lists/modelModifier.talon-list
+++ b/GPT/lists/modelModifier.talon-list
@@ -3,6 +3,3 @@ list: user.modelModifier
 
 # Construct snippet with the response
 snip: snip
-
-# Keep track of the questions and responses as a conversation
-thread: thread

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -105,6 +105,9 @@ def generate_payload(
     notification = "GPT Task Started"
     if len(GPTState.context) > 0:
         notification += ": Reusing Stored Context"
+    if GPTState.thread_enabled:
+        notification += ", Threading Enabled"
+
     notify(notification)
     TOKEN = get_token()
 
@@ -133,8 +136,8 @@ def generate_payload(
         if item is not None
     ]
 
-    reused_context = GPTState.context
-    if modifier == "thread":
+    reused_context = list(GPTState.context)
+    if GPTState.thread_enabled:
         reused_context += GPTState.thread
 
     current_query = [prompt, content]

--- a/lib/modelState.py
+++ b/lib/modelState.py
@@ -9,6 +9,7 @@ class GPTState:
     last_was_pasted: ClassVar[bool] = False
     context: ClassVar[list] = []
     thread: ClassVar[list] = []
+    thread_enabled: ClassVar[bool] = False
 
     @classmethod
     def clear_context(cls):
@@ -21,6 +22,18 @@ class GPTState:
         """Create a new thread"""
         cls.thread = []
         actions.app.notify("Created a new thread")
+
+    @classmethod
+    def enable_thread(cls):
+        """Enable threading"""
+        cls.thread_enabled = True
+        actions.app.notify("Enabled threading")
+
+    @classmethod
+    def disable_thread(cls):
+        """Disable threading"""
+        cls.thread_enabled = False
+        actions.app.notify("Disabled threading")
 
     @classmethod
     def push_context(cls, context: dict[str, any]):


### PR DESCRIPTION
- We're trying to simplify the grammar
- as the first step in removing the thread from a modifier is to make it available as a setting that can be enabled