### PR TITLE
Fix: `send_request` forward mutated `prompt` to `content`

### DIFF
--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -152,6 +152,7 @@ def send_request(
             prompt["text"] = (
                 prompt["text"] + '\n\n"""' + content_to_process["text"] + '"""'  # type: ignore a Prompt has to be of type text
             )
+            content = [prompt]
     else:
         # If there isn't any content to process,
         # we just use the prompt and nothing else


### PR DESCRIPTION
Just checking out this repo for the first time. Thanks for your work on this!

#147 introduces a bug whereby user content isn't forwarded to the model. Simple fix here.