### PR TITLE
Fix Header Handling for Azure-Specific Authorization

### DIFF
--- a/Images/ai-images.py
+++ b/Images/ai-images.py
@@ -15,10 +15,12 @@ class Actions:
 
         url = "https://api.openai.com/v1/images/generations"
         TOKEN = get_token()
-        headers = {
-            "Content-Type": "application/json",
-            "Authorization": f"Bearer {TOKEN}",
-        }
+        headers = {"Content-Type": "application/json"}
+        # If the model endpoint is Azure, we need to use a different header
+        if "azure.com" in url:
+            headers["api-key"] = TOKEN
+        else:
+            headers["Authorization"] = f"Bearer {TOKEN}"
         data = {
             "model": "dall-e-3",
             "prompt": prompt,

--- a/Images/ai-images.py
+++ b/Images/ai-images.py
@@ -19,6 +19,7 @@ class Actions:
         # If the model endpoint is Azure, we need to use a different header
         if "azure.com" in url:
             headers["api-key"] = TOKEN
+       # otherwise default to the standard header format for openai
         else:
             headers["Authorization"] = f"Bearer {TOKEN}"
         data = {

--- a/Images/ai-images.py
+++ b/Images/ai-images.py
@@ -19,7 +19,7 @@ class Actions:
         # If the model endpoint is Azure, we need to use a different header
         if "azure.com" in url:
             headers["api-key"] = TOKEN
-       # otherwise default to the standard header format for openai
+        # otherwise default to the standard header format for openai
         else:
             headers["Authorization"] = f"Bearer {TOKEN}"
         data = {

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -134,9 +134,15 @@ def send_request(
     system_messages += GPTState.context
 
     headers = {
-        "Content-Type": "application/json",
-        "Authorization": f"Bearer {TOKEN}",
+    "Content-Type": "application/json"
     }
+
+    # If the model endpoint is Azure, we need to use a different header
+    if "azure.com" in settings.get("user.model_endpoint"):
+        headers["api-key"] = TOKEN
+    else:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+
 
     content: list[GPTMessageItem] = []
     if content_to_process is not None:

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -133,17 +133,6 @@ def send_request(
 
     system_messages += GPTState.context
 
-    headers = {
-    "Content-Type": "application/json"
-    }
-
-    # If the model endpoint is Azure, we need to use a different header
-    if "azure.com" in settings.get("user.model_endpoint"):
-        headers["api-key"] = TOKEN
-    else:
-        headers["Authorization"] = f"Bearer {TOKEN}"
-
-
     content: list[GPTMessageItem] = []
     if content_to_process is not None:
         if content_to_process["type"] == "image_url":
@@ -186,6 +175,15 @@ def send_request(
         data["tools"] = tools
 
     url: str = settings.get("user.model_endpoint")  # type: ignore
+    headers = {
+    "Content-Type": "application/json"
+    }
+    # If the model endpoint is Azure, we need to use a different header
+    if "azure.com" in url:
+        headers["api-key"] = TOKEN
+    else:
+        headers["Authorization"] = f"Bearer {TOKEN}"
+
     raw_response = requests.post(url, headers=headers, data=json.dumps(data))
 
     match raw_response.status_code:

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -175,9 +175,7 @@ def send_request(
         data["tools"] = tools
 
     url: str = settings.get("user.model_endpoint")  # type: ignore
-    headers = {
-    "Content-Type": "application/json"
-    }
+    headers = {"Content-Type": "application/json"}
     # If the model endpoint is Azure, we need to use a different header
     if "azure.com" in url:
         headers["api-key"] = TOKEN


### PR DESCRIPTION
# Description
This pull request fixes #161 by updating header management for Azure-specific authorization requirements in both the `lib/modelHelpers.py` and `Images/ai-images.py` files.

## Changes

1. **lib/modelHelpers.py:**
   - **Moved header setup:** The Authorization and Content-Type headers were moved closer to the request execution.
   - **Conditional logic for Azure endpoints:** For Azure endpoints, the api-key header is used instead of Authorization. Non-Azure endpoints continue using the Authorization header.

2. **Images/ai-images.py:**
   - **Modified header setup:** Added conditional logic to handle the api-key header for Azure and Authorization for OpenAI.

## Note
While the headers have been updated for Azure compatibility, image generation will still not function with Azure, as the endpoint remains hardcoded to OpenAI. A future PR will be required to support Azure image generation.