### PR TITLE
Rename Cursorless ordinal_or_last capture.

### DIFF
--- a/.docs/src/content/docs/reference/gpt.mdx
+++ b/.docs/src/content/docs/reference/gpt.mdx
@@ -9,10 +9,10 @@ import FetchedData from "../../../components/FetchedData.astro";
 
 GPT commands make requests to an LLM endpoint. In our grammar, each GPT command is prefixed with the word `model`. A model command has 4 parts
 
--   `model`
--   A prompt name
--   A source _(optional; defaults to selected text)_
--   A destination _(optional; defaults to paste)_
+- `model`
+- A prompt name
+- A source _(optional; defaults to selected text)_
+- A destination _(optional; defaults to paste)_
 
 You can mix and match any combination of prompt, source, and destination.
 

--- a/copilot/copilot.talon
+++ b/copilot/copilot.talon
@@ -16,7 +16,8 @@ pilot new file <user.cursorless_ordinal_or_last>:
 pilot copy <user.cursorless_ordinal_or_last>:
     user.copilot_focus_code_block(cursorless_ordinal_or_last)
     edit.copy()
-pilot bring <user.cursorless_ordinal_or_last>: user.copilot_bring_code_block(cursorless_ordinal_or_last)
+pilot bring <user.cursorless_ordinal_or_last>:
+    user.copilot_bring_code_block(cursorless_ordinal_or_last)
 pilot bring <user.cursorless_ordinal_or_last> {user.makeshift_destination} <user.cursorless_target>:
     user.cursorless_command(makeshift_destination, cursorless_target)
     user.copilot_bring_code_block(cursorless_ordinal_or_last)

--- a/copilot/copilot.talon
+++ b/copilot/copilot.talon
@@ -10,16 +10,16 @@ pilot nope: user.vscode("editor.action.inlineSuggest.undo")
 pilot cancel: user.vscode("editor.action.inlineSuggest.hide")
 pilot block last: user.vscode("workbench.action.chat.previousCodeBlock")
 pilot block next: user.vscode("workbench.action.chat.nextCodeBlock")
-pilot new file <user.ordinal_or_last>:
-    user.copilot_focus_code_block(ordinal_or_last)
+pilot new file <user.cursorless_ordinal_or_last>:
+    user.copilot_focus_code_block(cursorless_ordinal_or_last)
     user.vscode("workbench.action.chat.insertIntoNewFile")
-pilot copy <user.ordinal_or_last>:
-    user.copilot_focus_code_block(ordinal_or_last)
+pilot copy <user.cursorless_ordinal_or_last>:
+    user.copilot_focus_code_block(cursorless_ordinal_or_last)
     edit.copy()
-pilot bring <user.ordinal_or_last>: user.copilot_bring_code_block(ordinal_or_last)
-pilot bring <user.ordinal_or_last> {user.makeshift_destination} <user.cursorless_target>:
+pilot bring <user.cursorless_ordinal_or_last>: user.copilot_bring_code_block(cursorless_ordinal_or_last)
+pilot bring <user.cursorless_ordinal_or_last> {user.makeshift_destination} <user.cursorless_target>:
     user.cursorless_command(makeshift_destination, cursorless_target)
-    user.copilot_bring_code_block(ordinal_or_last)
+    user.copilot_bring_code_block(cursorless_ordinal_or_last)
 pilot chat [<user.prose>]$: user.copilot_chat(prose or "")
 pilot {user.copilot_slash_command} <user.cursorless_target> [to <user.prose>]$:
     user.cursorless_command("setSelection", cursorless_target)


### PR DESCRIPTION
Updated this to align with changes in Cursorless: https://github.com/cursorless-dev/cursorless/commit/1e996d2c035a37cf5972956a53cbfae54420aceb