### PR TITLE
Fix model resolution to ensure consistent model name handling

### DIFF
--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from typing import Any, Optional
 
@@ -169,18 +168,6 @@ class UserActions:
         if prompt.startswith("ask"):
             text_to_process = format_message(prompt.removeprefix("ask"))
             prompt = "Generate text that satisfies the question or request given in the input."
-
-        # Convert model name from the model list to actual model name or use default
-        if model == "model":
-            # Check for deprecated setting first for backward compatibility
-            openai_model: str = settings.get("user.openai_model")  # type: ignore
-            if openai_model != "do_not_use":
-                logging.warning(
-                    "The setting 'user.openai_model' is deprecated. Please use 'user.model_default' instead."
-                )
-                model = openai_model
-            else:
-                model = settings.get("user.model_default")  # type: ignore
 
         response = gpt_query(
             format_message(prompt), text_to_process, model, destination


### PR DESCRIPTION
Added a centralized resolve_model_name function in modelHelpers.py to ensure that all commands using {user.model} properly resolve to the default model when the placeholder "model" is used.

This wasn't working for "model shell", for example.