### PR TITLE
Fix Cursorless integration with AI model commands

### DIFF
--- a/GPT/gpt-cursorless.talon
+++ b/GPT/gpt-cursorless.talon
@@ -6,29 +6,29 @@ tag: user.cursorless
 # Paste it to the cursor if no target is specified
 {user.model} <user.modelSimplePrompt> <user.cursorless_target> [<user.cursorless_destination>]$:
     text = user.cursorless_get_text_list(cursorless_target)
-    result = user.gpt_apply_prompt(user.modelSimplePrompt, model, text)
+    result = user.gpt_apply_prompt_for_cursorless(user.modelSimplePrompt, model, text)
     default_destination = user.cursorless_create_destination(cursorless_target)
     user.cursorless_insert(cursorless_destination or default_destination, result)
 
 # Add the text from a cursorless target to your context
 {user.model} pass <user.cursorless_target> to context$:
-    text = user.cursorless_get_text(cursorless_target)
+    text = user.cursorless_get_text_list(cursorless_target)
     user.gpt_push_context(text)
 
 # Add the text from a cursorless target to a new context
-{user.model} pass <user.cursorless_target> to new context'$:
-    text = user.cursorless_get_text(cursorless_target)
+{user.model} pass <user.cursorless_target> to new context$:
+    text = user.cursorless_get_text_list(cursorless_target)
     user.gpt_clear_context()
     user.gpt_push_context(text)
 
 # Add the text from a cursorless target to the current thread
 {user.model} pass <user.cursorless_target> to thread$:
-    text = user.cursorless_get_text(cursorless_target)
+    text = user.cursorless_get_text_list(cursorless_target)
     user.gpt_push_thread(text)
 
 # Add the text from a cursorless target to a new thread
 {user.model} pass <user.cursorless_target> to new thread$:
-    text = user.cursorless_get_text(cursorless_target)
+    text = user.cursorless_get_text_list(cursorless_target)
     user.gpt_clear_thread()
     user.gpt_push_thread(text)
 
@@ -37,6 +37,6 @@ tag: user.cursorless
 {user.model} apply [from] clip <user.cursorless_target>$:
     prompt = clip.text()
     text = user.cursorless_get_text_list(cursorless_target)
-    result = user.gpt_apply_prompt(prompt, model, text)
+    result = user.gpt_apply_prompt_for_cursorless(prompt, model, text)
     default_destination = user.cursorless_create_destination(cursorless_target)
     user.cursorless_insert(default_destination, result)

--- a/GPT/gpt.py
+++ b/GPT/gpt.py
@@ -123,12 +123,16 @@ class UserActions:
         """Enable threading of subsequent requests"""
         GPTState.disable_thread()
 
-    def gpt_push_context(context: str):
+    def gpt_push_context(context: str | list[str]):
         """Add the selected text to the stored context"""
+        if isinstance(context, list):
+            context = "\n".join(context)
         GPTState.push_context(format_message(context))
 
-    def gpt_push_thread(content: str):
+    def gpt_push_thread(content: str | list[str]):
         """Add the selected text to the active thread"""
+        if isinstance(content, list):
+            content = "\n".join(content)
         GPTState.push_thread(format_messages("user", [format_message(content)]))
 
     def gpt_additional_user_context() -> list[str]:
@@ -175,6 +179,25 @@ class UserActions:
 
         actions.user.gpt_insert_response(response, destination)
         return response
+
+    def gpt_apply_prompt_for_cursorless(
+        prompt: str,
+        model: str,
+        source: list[str],
+    ) -> str:
+        """Apply a prompt to text from Cursorless and return a string result.
+        This function is specifically designed for Cursorless integration
+        and does not trigger insertion actions."""
+
+        # Join the list into a single string
+        source_text = "\n".join(source)
+        text_to_process = format_message(source_text)
+
+        # Send the request but don't insert the response (Cursorless will handle insertion)
+        response = gpt_query(format_message(prompt), text_to_process, model, "")
+
+        # Return just the text string
+        return extract_message(response)
 
     def gpt_pass(source: str = "", destination: str = "") -> None:
         """Passes a response from source to destination"""


### PR DESCRIPTION
Fixes #170 

This fixes an issue with the cursorless commands not working properly due to changes in function return types. The fix:
1. Adds a dedicated gpt_apply_prompt_for_cursorless function for Cursorless integration
2. Updates gpt_push_context and gpt_push_thread to handle both string and list inputs
3. Updates all Cursorless commands to use cursorless_get_text_list consistently
4. Fixes command format by removing unnecessary apostrophe

🤖 Generated with [Claude Code](https://claude.ai/code)