### PR TITLE
Remove Temperature from Llm Cli

### DIFF
--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -5,7 +5,6 @@ import os
 import platform
 import subprocess
 from typing import Literal, Optional
-
 import requests
 from talon import actions, app, clip, settings
 
@@ -257,8 +256,10 @@ def send_request_to_llm_cli(
 ) -> GPTMessageItem:
     """Send a request to the LLM CLI tool and return the response"""
     # Build command.
-    command: list[str] = [settings.get("user.model_llm_path")]  # type: ignore
-    command.append(prompt["text"])  # type: ignore
+    llm_binary: str = settings.get("user.model_llm_path") # type: ignore
+    command: list[str] = [llm_binary]
+    assert "text" in prompt
+    command.append(prompt["text"])
     cmd_input: bytes | None = None
     if content_to_process and content_to_process["type"] == "image_url":
         img_url: str = content_to_process["image_url"]["url"]  # type: ignore
@@ -269,7 +270,8 @@ def send_request_to_llm_cli(
         else:
             command.extend(["-a", img_url])
     command.extend(["-m", model])
-    command.extend(["-o", "temperature", str(settings.get("user.model_temperature"))])
+
+
     if system_message:
         command.extend(["-s", system_message])
 

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -5,6 +5,7 @@ import os
 import platform
 import subprocess
 from typing import Literal, Optional
+
 import requests
 from talon import actions, app, clip, settings
 
@@ -256,7 +257,7 @@ def send_request_to_llm_cli(
 ) -> GPTMessageItem:
     """Send a request to the LLM CLI tool and return the response"""
     # Build command.
-    llm_binary: str = settings.get("user.model_llm_path") # type: ignore
+    llm_binary: str = settings.get("user.model_llm_path")  # type: ignore
     command: list[str] = [llm_binary]
     assert "text" in prompt
     command.append(prompt["text"])
@@ -270,7 +271,6 @@ def send_request_to_llm_cli(
         else:
             command.extend(["-a", img_url])
     command.extend(["-m", model])
-
 
     if system_message:
         command.extend(["-s", system_message])


### PR DESCRIPTION
To my understanding, each model in the llm cli can specify its own arbitrary options. As a result, for some models temperature is called `temp` and for others it is called `temperature`. It could also theoretically be called something different entirely. If you try to pass in an option that doesn't exist, llm will fail. 

Currently, running Llama-3 or Deepseek with llm in our repo fails since they call it `temp`. 

As a fix you can run `llm models --options` but that gets options for all models installed and then you need to parse that. It is in yaml so we cannot natively parse it inside Talon without using write a hacky yaml parser subset.

You can concievably write a function like this and it would be fine to do this but there is no guarantee this API is stable and could easily break things. It seems to add another maintenance / testing challenge since this could reasonably be different in different versions of llm.

```py
import subprocess

def get_model_options():
    """Runs `llm models --options` and returns the output as a string."""
    result = subprocess.run(
        ["llm", "models", "--options"], capture_output=True, text=True
    )
    return result.stdout


def parse_model_options(models_output, model_name: str):
    """Parses the output of `llm models --options` to find the options for a given model."""
    lines: list[str] = models_output.splitlines()
    in_target_model = False
    model_options = []

    for line in lines:
        if "Options:" in line:
            in_target_model = model_name in line
        elif in_target_model and line.startswith("    "):  # Options indentation
            model_options.append(line.strip())
        elif in_target_model and not line.startswith("    "):
            break  # Stop when we leave the model section

    return model_options


def check_temp_keys(model_options):
    """Checks if the model has 'temp', 'temperature', or neither in its options."""
    has_temp = any("temp" in opt for opt in model_options)
    has_temperature = any("temperature" in opt for opt in model_options)

    if has_temperature:
        return "temperature"
    elif has_temp:
        return "temp"
    else:
        return "neither"
```

I am not sure if people are using the temperature setting but if they aren't I wonder if this should just be removed. I personally always just use the default temperature