### PR TITLE
Add thread continuation support through 'and' keyword (continueLast)

### DIFF
--- a/GPT/gpt-cursorless.talon
+++ b/GPT/gpt-cursorless.talon
@@ -4,9 +4,9 @@ tag: user.cursorless
 
 # Apply a prompt to any text, and output it any target
 # Paste it to the cursor if no target is specified
-{user.model} <user.modelSimplePrompt> <user.cursorless_target> [<user.cursorless_destination>]$:
+{user.model} [{user.thread}] <user.modelSimplePrompt> <user.cursorless_target> [<user.cursorless_destination>]$:
     text = user.cursorless_get_text_list(cursorless_target)
-    result = user.gpt_apply_prompt_for_cursorless(user.modelSimplePrompt, model, text)
+    result = user.gpt_apply_prompt_for_cursorless(user.modelSimplePrompt, model, thread or "", text)
     default_destination = user.cursorless_create_destination(cursorless_target)
     user.cursorless_insert(cursorless_destination or default_destination, result)
 
@@ -23,9 +23,9 @@ tag: user.cursorless
 
 # Applies an arbitrary prompt from the clipboard to a cursorless target.
 # Useful for applying complex/custom prompts that need to be drafted in a text editor.
-{user.model} apply [from] clip <user.cursorless_target>$:
+{user.model} [{user.thread}] apply [from] clip <user.cursorless_target>$:
     prompt = clip.text()
     text = user.cursorless_get_text_list(cursorless_target)
-    result = user.gpt_apply_prompt_for_cursorless(prompt, model, text)
+    result = user.gpt_apply_prompt_for_cursorless(prompt, model, thread or "", text)
     default_destination = user.cursorless_create_destination(cursorless_target)
     user.cursorless_insert(default_destination, result)

--- a/GPT/gpt-shell.talon
+++ b/GPT/gpt-shell.talon
@@ -4,11 +4,11 @@ mode: command
 # Generate a shell command by specifying what you want it to do
 # You have to explicitly confirm the output of the model before
 # it is pasted so nothing is accidentally executed
-{user.model} shell <user.text>$:
-    result = user.gpt_generate_shell(user.text, model)
+{user.model} [{user.thread}] shell <user.text>$:
+    result = user.gpt_generate_shell(user.text, model, thread or "")
     user.confirmation_gui_append(result)
 
 # Generate a SQL command by specifying what you want it to return
-{user.model} (sequel | sql) <user.text>$:
-    result = user.gpt_generate_sql(user.text, model)
+{user.model} [{user.thread}] (sequel | sql) <user.text>$:
+    result = user.gpt_generate_sql(user.text, model, thread or "")
     user.confirmation_gui_append(result)

--- a/GPT/gpt.talon
+++ b/GPT/gpt.talon
@@ -6,23 +6,24 @@
 #   Example: `model explain this` -> Explains the selected text and pastes in place
 #   Example: `model fix grammar clip to browser` -> Fixes the grammar of the text on the clipboard and opens in browser`
 #   Example: `four o mini explain this` -> Uses gpt-4o-mini model to explain the selected text
-{user.model} <user.modelPrompt> [{user.modelSource}] [{user.modelDestination}]$:
-    user.gpt_apply_prompt(modelPrompt, model, modelSource or "", modelDestination or "")
+#   Example: `model and explain this` -> Explains the selected text and pastes in place, continuing the most recent conversation thread
+{user.model} [{user.thread}] <user.modelPrompt> [{user.modelSource}] [{user.modelDestination}]$:
+    user.gpt_apply_prompt(modelPrompt, model, thread or "", modelSource or "", modelDestination or "")
 
 # Select the last GPT response so you can edit it further
 {user.model} take response: user.gpt_select_last()
 
 # Applies an arbitrary prompt from the clipboard to selected text and pastes the result.
 # Useful for applying complex/custom prompts that need to be drafted in a text editor.
-{user.model} apply [from] clip$:
+{user.model} [{user.thread}] apply [from] clip$:
     prompt = clip.text()
     text = edit.selected_text()
-    result = user.gpt_apply_prompt(prompt, model, text)
+    result = user.gpt_apply_prompt(prompt, model, thread or "", text)
     user.paste(result)
 
 # Reformat the last dictation with additional context or formatting instructions
-{user.model} [nope] that was <user.text>$:
-    result = user.gpt_reformat_last(text, model)
+{user.model} [{user.thread}] [nope] that was <user.text>$:
+    result = user.gpt_reformat_last(text, model, thread or "")
     user.paste(result)
 
 # Enable debug logging so you can more details about messages being sent

--- a/GPT/lists/thread.talon-list
+++ b/GPT/lists/thread.talon-list
@@ -1,0 +1,3 @@
+list: user.thread
+-
+and: continueLast

--- a/lib/talonSettings.py
+++ b/lib/talonSettings.py
@@ -10,6 +10,7 @@ mod.list("modelPrompt", desc="GPT Prompts")
 mod.list("model", desc="The name of the model")
 mod.list("modelDestination", desc="What to do after returning the model response")
 mod.list("modelSource", desc="Where to get the text from for the GPT")
+mod.list("thread", desc="Which conversation thread to continue")
 
 
 # model prompts can be either static and predefined by this repo or custom outside of it


### PR DESCRIPTION
- Add thread.talon-list with 'and: continueLast' to continue the most recent conversation
- Add thread parameter to all model functions and commands
- Display warning when thread continuation is attempted without the llm CLI
- Support the thread parameter everywhere {user.model} is used

Thread continuation works with all model commands, e.g.:
- 'model and explain this'
- 'four o mini and shell list all directories'

This feature currently requires setting user.model_endpoint = 'llm'