### PR TITLE
Remove unused get_clipboard_image function

### DIFF
--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -400,15 +400,3 @@ def send_request_to_llm_cli(
         raise e
 
 
-def get_clipboard_image():
-    try:
-        clipped_image = clip.image()
-        if not clipped_image:
-            raise Exception("No image found in clipboard")
-
-        data = clipped_image.encode().data()
-        base64_image = base64.b64encode(data).decode("utf-8")
-        return base64_image
-    except Exception as e:
-        print(e)
-        raise Exception("Invalid image in clipboard")

--- a/lib/modelHelpers.py
+++ b/lib/modelHelpers.py
@@ -398,5 +398,3 @@ def send_request_to_llm_cli(
     except Exception as e:
         notify("GPT Failure: Check the Talon Log")
         raise e
-
-


### PR DESCRIPTION
## Summary
- Removes the unused `get_clipboard_image` function from `lib/modelHelpers.py`
- This function was not being referenced anywhere in the codebase
- Its functionality is already covered by the `format_clipboard` function

## Test plan
- [x] Verified function is not used anywhere with grep search
- [x] Confirmed similar functionality exists in `format_clipboard`
- [x] No functional changes to existing behavior

🤖 Generated with [Claude Code](https://claude.ai/code)