### PR TITLE
Add undo functionality for chat command

### DIFF
--- a/copilot/copilot.talon
+++ b/copilot/copilot.talon
@@ -22,6 +22,7 @@ pilot bring <user.cursorless_ordinal_or_last> {user.makeshift_destination} <user
     user.cursorless_command(makeshift_destination, cursorless_target)
     user.copilot_bring_code_block(cursorless_ordinal_or_last)
 pilot chat [<user.prose>]$: user.copilot_chat(prose or "")
+pilot undo chat: user.vscode("workbench.action.chat.undoEdit")
 pilot {user.copilot_slash_command} <user.cursorless_target> [to <user.prose>]$:
     user.cursorless_command("setSelection", cursorless_target)
     user.copilot_inline_chat(copilot_slash_command or "", prose or "")


### PR DESCRIPTION
This is a short PR to add a talonscript command to access the "Undo Request" action (for the chat interface, rather than the inline interface).

Please let me know if the command should be different or if I'm missing something else about a better way to do this.