### PR TITLE
Resolve recently-introduced grammar conflict in copilot.talon.

### DIFF
--- a/copilot/copilot.talon
+++ b/copilot/copilot.talon
@@ -2,8 +2,8 @@ app: vscode
 not tag: user.codeium
 -
 pilot jest: user.vscode("editor.action.inlineSuggest.trigger")
-pilot next: user.vscode("editor.action.inlineSuggest.showNext")
-pilot (previous | last): user.vscode("editor.action.inlineSuggest.showPrevious")
+pilot jest next: user.vscode("editor.action.inlineSuggest.showNext")
+pilot jest (previous | last): user.vscode("editor.action.inlineSuggest.showPrevious")
 pilot yes: user.vscode("editor.action.inlineSuggest.commit")
 pilot yes word: user.vscode("editor.action.inlineSuggest.acceptNextWord")
 pilot nope: user.vscode("editor.action.inlineSuggest.undo")


### PR DESCRIPTION
cc @BoltonBailey

I'm assuming that chatEditor.action.navigateNext will be used more than editor.action.inlineSuggest.showNext. The former is a much more recently-introduced command, however, so this might surprise some people.