### PR TITLE
Add GPT semantic command stack with guarded execution

### DIFF
--- a/.test/test_gpt_semantic_executor.py
+++ b/.test/test_gpt_semantic_executor.py
@@ -69,7 +69,9 @@ def test_mapping_includes_launch_app(monkeypatch) -> None:
 
 
 def test_launch_app_uses_resolved_command(monkeypatch) -> None:
-    monkeypatch.setattr(helpers, "resolve_launch_command", lambda _name: "gnome-text-editor")
+    monkeypatch.setattr(
+        helpers, "resolve_launch_command", lambda _name: "gnome-text-editor"
+    )
     plan = GptSemanticPlan([GptSemanticStep("launch_app", {"app_name": "Gedit"})])
     runner = FakeRunner()
     execute_plan(plan, runner=runner)
@@ -77,7 +79,9 @@ def test_launch_app_uses_resolved_command(monkeypatch) -> None:
 
 
 def test_stop_on_first_error() -> None:
-    plan = GptSemanticPlan([GptSemanticStep("new_tab", {}), GptSemanticStep("copy", {})])
+    plan = GptSemanticPlan(
+        [GptSemanticStep("new_tab", {}), GptSemanticStep("copy", {})]
+    )
     runner = FakeRunner(fail_call="app.tab_open")
     try:
         execute_plan(plan, runner=runner)
@@ -90,15 +94,21 @@ def test_stop_on_first_error() -> None:
 def test_browser_fallbacks() -> None:
     msg = "Action 'browser.go' exists but the Module method is empty and no Context reimplements it"
     runner = FakeRunner(fail_call="browser.go", fail_message=msg)
-    execute_plan(GptSemanticPlan([GptSemanticStep("go_url", {"url": "https://x"})]), runner)
+    execute_plan(
+        GptSemanticPlan([GptSemanticStep("go_url", {"url": "https://x"})]), runner
+    )
     assert ("key", ("ctrl-l",)) in runner.calls
     assert ("insert", ("https://x",)) in runner.calls
 
 
 def test_switch_app_waits_for_focus(monkeypatch) -> None:
     waits: list[tuple[str, str | None]] = []
-    monkeypatch.setattr(step_executor, "wait_for_app_focus", lambda _r, n, c=None: waits.append((n, c)))
-    plan = GptSemanticPlan([GptSemanticStep("switch_app", {"app_name": "Google Chrome"})])
+    monkeypatch.setattr(
+        step_executor, "wait_for_app_focus", lambda _r, n, c=None: waits.append((n, c))
+    )
+    plan = GptSemanticPlan(
+        [GptSemanticStep("switch_app", {"app_name": "Google Chrome"})]
+    )
     runner = FakeRunner()
     execute_plan(plan, runner=runner)
     assert runner.calls[0] == ("user.switcher_focus", ("Google Chrome",))
@@ -107,8 +117,12 @@ def test_switch_app_waits_for_focus(monkeypatch) -> None:
 
 def test_execute_plan_applies_settle_after_each_step(monkeypatch) -> None:
     settled: list[str] = []
-    monkeypatch.setattr(step_executor, "settle_after_step", lambda action, _r: settled.append(action))
-    plan = GptSemanticPlan([GptSemanticStep("new_tab", {}), GptSemanticStep("copy", {})])
+    monkeypatch.setattr(
+        step_executor, "settle_after_step", lambda action, _r: settled.append(action)
+    )
+    plan = GptSemanticPlan(
+        [GptSemanticStep("new_tab", {}), GptSemanticStep("copy", {})]
+    )
     execute_plan(plan, runner=FakeRunner())
     assert settled == ["new_tab", "copy"]
 
@@ -116,9 +130,15 @@ def test_execute_plan_applies_settle_after_each_step(monkeypatch) -> None:
 def test_switch_app_falls_back_to_launch_if_not_running(monkeypatch) -> None:
     waits: list[tuple[str, str | None]] = []
     monkeypatch.setattr(step_executor, "is_running_app", lambda _name: False)
-    monkeypatch.setattr(step_executor, "launch_candidates", lambda _name: ["google-chrome"])
-    monkeypatch.setattr(step_executor, "wait_for_app_focus", lambda _r, n, c=None: waits.append((n, c)))
-    plan = GptSemanticPlan([GptSemanticStep("switch_app", {"app_name": "Google Chrome"})])
+    monkeypatch.setattr(
+        step_executor, "launch_candidates", lambda _name: ["google-chrome"]
+    )
+    monkeypatch.setattr(
+        step_executor, "wait_for_app_focus", lambda _r, n, c=None: waits.append((n, c))
+    )
+    plan = GptSemanticPlan(
+        [GptSemanticStep("switch_app", {"app_name": "Google Chrome"})]
+    )
     runner = FakeRunner()
     execute_plan(plan, runner=runner)
     assert runner.calls[0] == ("user.switcher_launch", ("google-chrome",))

--- a/.test/test_gpt_semantic_executor.py
+++ b/.test/test_gpt_semantic_executor.py
@@ -1,0 +1,125 @@
+"""Executor behavior tests for GPT semantic commands.
+
+Purpose:
+- Verifies action mapping, browser fallback behavior, synchronization hooks, and stop-on-error policy.
+
+Called from:
+- Pytest suite in `user/talon-ai-tools/.test`.
+"""
+
+import sys
+
+sys.path.append(".")
+
+from GPT.semantic import gpt_semantic_executor_helpers as helpers
+from GPT.semantic import gpt_semantic_step_executor as step_executor
+from GPT.semantic.gpt_semantic_executor import GptSemanticExecutionError, execute_plan
+from GPT.semantic.gpt_semantic_types import GptSemanticPlan, GptSemanticStep
+
+
+class Proxy:
+    def __init__(self, runner: "FakeRunner", prefix: str):
+        self._runner = runner
+        self._prefix = prefix
+
+    def __getattr__(self, name: str):
+        def call(*args):
+            self._runner.record(f"{self._prefix}.{name}", *args)
+
+        return call
+
+
+class FakeRunner:
+    def __init__(self, fail_call: str | None = None, fail_message: str = "boom"):
+        self.calls: list[tuple[str, tuple[object, ...]]] = []
+        self.fail_call = fail_call
+        self.fail_message = fail_message
+        self.user = Proxy(self, "user")
+        self.browser = Proxy(self, "browser")
+        self.app = Proxy(self, "app")
+        self.edit = Proxy(self, "edit")
+
+    def record(self, name: str, *args) -> None:
+        self.calls.append((name, args))
+        if name == self.fail_call:
+            raise RuntimeError(self.fail_message)
+
+    def insert(self, text: str) -> None:
+        self.record("insert", text)
+
+    def key(self, combo: str) -> None:
+        self.record("key", combo)
+
+    def sleep(self, value: str) -> None:
+        self.record("sleep", value)
+
+
+def test_mapping_includes_launch_app(monkeypatch) -> None:
+    monkeypatch.setattr(helpers, "resolve_launch_command", lambda _name: "text-editor")
+    plan = GptSemanticPlan(
+        steps=[
+            GptSemanticStep("launch_app", {"app_name": "Text Editor"}),
+            GptSemanticStep("new_tab", {}),
+        ]
+    )
+    runner = FakeRunner()
+    execute_plan(plan, runner=runner)
+    assert runner.calls[0] == ("user.switcher_launch", ("text-editor",))
+    assert runner.calls[1] == ("app.tab_open", ())
+
+
+def test_launch_app_uses_resolved_command(monkeypatch) -> None:
+    monkeypatch.setattr(helpers, "resolve_launch_command", lambda _name: "gnome-text-editor")
+    plan = GptSemanticPlan([GptSemanticStep("launch_app", {"app_name": "Gedit"})])
+    runner = FakeRunner()
+    execute_plan(plan, runner=runner)
+    assert runner.calls[0] == ("user.switcher_launch", ("gnome-text-editor",))
+
+
+def test_stop_on_first_error() -> None:
+    plan = GptSemanticPlan([GptSemanticStep("new_tab", {}), GptSemanticStep("copy", {})])
+    runner = FakeRunner(fail_call="app.tab_open")
+    try:
+        execute_plan(plan, runner=runner)
+        assert False
+    except GptSemanticExecutionError as exc:
+        assert "Step 1 (new_tab)" in str(exc)
+    assert len(runner.calls) == 1
+
+
+def test_browser_fallbacks() -> None:
+    msg = "Action 'browser.go' exists but the Module method is empty and no Context reimplements it"
+    runner = FakeRunner(fail_call="browser.go", fail_message=msg)
+    execute_plan(GptSemanticPlan([GptSemanticStep("go_url", {"url": "https://x"})]), runner)
+    assert ("key", ("ctrl-l",)) in runner.calls
+    assert ("insert", ("https://x",)) in runner.calls
+
+
+def test_switch_app_waits_for_focus(monkeypatch) -> None:
+    waits: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(step_executor, "wait_for_app_focus", lambda _r, n, c=None: waits.append((n, c)))
+    plan = GptSemanticPlan([GptSemanticStep("switch_app", {"app_name": "Google Chrome"})])
+    runner = FakeRunner()
+    execute_plan(plan, runner=runner)
+    assert runner.calls[0] == ("user.switcher_focus", ("Google Chrome",))
+    assert waits == [("Google Chrome", None)]
+
+
+def test_execute_plan_applies_settle_after_each_step(monkeypatch) -> None:
+    settled: list[str] = []
+    monkeypatch.setattr(step_executor, "settle_after_step", lambda action, _r: settled.append(action))
+    plan = GptSemanticPlan([GptSemanticStep("new_tab", {}), GptSemanticStep("copy", {})])
+    execute_plan(plan, runner=FakeRunner())
+    assert settled == ["new_tab", "copy"]
+
+
+def test_switch_app_falls_back_to_launch_if_not_running(monkeypatch) -> None:
+    waits: list[tuple[str, str | None]] = []
+    monkeypatch.setattr(step_executor, "is_running_app", lambda _name: False)
+    monkeypatch.setattr(step_executor, "launch_candidates", lambda _name: ["google-chrome"])
+    monkeypatch.setattr(step_executor, "wait_for_app_focus", lambda _r, n, c=None: waits.append((n, c)))
+    plan = GptSemanticPlan([GptSemanticStep("switch_app", {"app_name": "Google Chrome"})])
+    runner = FakeRunner()
+    execute_plan(plan, runner=runner)
+    assert runner.calls[0] == ("user.switcher_launch", ("google-chrome",))
+    assert waits == [("Google Chrome", "google-chrome")]

--- a/.test/test_gpt_semantic_guardrails.py
+++ b/.test/test_gpt_semantic_guardrails.py
@@ -2,14 +2,19 @@ import sys
 
 sys.path.append(".")
 
-from GPT.semantic.gpt_semantic_guardrails import GptSemanticGuardrailError, validate_guardrails
+from GPT.semantic.gpt_semantic_guardrails import (
+    GptSemanticGuardrailError,
+    validate_guardrails,
+)
 from GPT.semantic.gpt_semantic_types import GptSemanticPlan, GptSemanticStep
 
 
 def test_step_limit() -> None:
     plan = GptSemanticPlan([GptSemanticStep("new_tab", {}) for _ in range(2)])
     try:
-        validate_guardrails(plan, max_steps=1, max_total_sleep_ms=2000, max_insert_chars=50)
+        validate_guardrails(
+            plan, max_steps=1, max_total_sleep_ms=2000, max_insert_chars=50
+        )
         assert False
     except GptSemanticGuardrailError as exc:
         assert "maximum is 1" in str(exc)
@@ -18,7 +23,9 @@ def test_step_limit() -> None:
 def test_sleep_budget() -> None:
     plan = GptSemanticPlan([GptSemanticStep("sleep", {"ms": 3000})])
     try:
-        validate_guardrails(plan, max_steps=5, max_total_sleep_ms=2000, max_insert_chars=50)
+        validate_guardrails(
+            plan, max_steps=5, max_total_sleep_ms=2000, max_insert_chars=50
+        )
         assert False
     except GptSemanticGuardrailError as exc:
         assert "Total sleep is" in str(exc)
@@ -27,7 +34,9 @@ def test_sleep_budget() -> None:
 def test_insert_length() -> None:
     plan = GptSemanticPlan([GptSemanticStep("insert_text", {"text": "x" * 10})])
     try:
-        validate_guardrails(plan, max_steps=5, max_total_sleep_ms=2000, max_insert_chars=5)
+        validate_guardrails(
+            plan, max_steps=5, max_total_sleep_ms=2000, max_insert_chars=5
+        )
         assert False
     except GptSemanticGuardrailError as exc:
         assert "insert_text exceeds 5" in str(exc)
@@ -36,7 +45,9 @@ def test_insert_length() -> None:
 def test_blocked_combo() -> None:
     plan = GptSemanticPlan([GptSemanticStep("key", {"combo": "ctrl-w"})])
     try:
-        validate_guardrails(plan, max_steps=5, max_total_sleep_ms=2000, max_insert_chars=50)
+        validate_guardrails(
+            plan, max_steps=5, max_total_sleep_ms=2000, max_insert_chars=50
+        )
         assert False
     except GptSemanticGuardrailError as exc:
         assert "blocked" in str(exc)

--- a/.test/test_gpt_semantic_guardrails.py
+++ b/.test/test_gpt_semantic_guardrails.py
@@ -1,0 +1,42 @@
+import sys
+
+sys.path.append(".")
+
+from GPT.semantic.gpt_semantic_guardrails import GptSemanticGuardrailError, validate_guardrails
+from GPT.semantic.gpt_semantic_types import GptSemanticPlan, GptSemanticStep
+
+
+def test_step_limit() -> None:
+    plan = GptSemanticPlan([GptSemanticStep("new_tab", {}) for _ in range(2)])
+    try:
+        validate_guardrails(plan, max_steps=1, max_total_sleep_ms=2000, max_insert_chars=50)
+        assert False
+    except GptSemanticGuardrailError as exc:
+        assert "maximum is 1" in str(exc)
+
+
+def test_sleep_budget() -> None:
+    plan = GptSemanticPlan([GptSemanticStep("sleep", {"ms": 3000})])
+    try:
+        validate_guardrails(plan, max_steps=5, max_total_sleep_ms=2000, max_insert_chars=50)
+        assert False
+    except GptSemanticGuardrailError as exc:
+        assert "Total sleep is" in str(exc)
+
+
+def test_insert_length() -> None:
+    plan = GptSemanticPlan([GptSemanticStep("insert_text", {"text": "x" * 10})])
+    try:
+        validate_guardrails(plan, max_steps=5, max_total_sleep_ms=2000, max_insert_chars=5)
+        assert False
+    except GptSemanticGuardrailError as exc:
+        assert "insert_text exceeds 5" in str(exc)
+
+
+def test_blocked_combo() -> None:
+    plan = GptSemanticPlan([GptSemanticStep("key", {"combo": "ctrl-w"})])
+    try:
+        validate_guardrails(plan, max_steps=5, max_total_sleep_ms=2000, max_insert_chars=50)
+        assert False
+    except GptSemanticGuardrailError as exc:
+        assert "blocked" in str(exc)

--- a/.test/test_gpt_semantic_launch_catalog.py
+++ b/.test/test_gpt_semantic_launch_catalog.py
@@ -1,0 +1,19 @@
+import sys
+
+sys.path.append(".")
+
+from GPT.semantic import gpt_semantic_launch_catalog as catalog
+
+
+def test_resolve_launch_command_prefers_name(monkeypatch) -> None:
+    rows = (("Text Editor", "gnome-text-editor"), ("Terminal", "gnome-terminal"))
+    monkeypatch.setattr(catalog, "launch_entries", lambda: rows)
+    assert catalog.resolve_launch_command("text editor") == "gnome-text-editor"
+
+
+def test_launch_context_text(monkeypatch) -> None:
+    rows = (("Text Editor", "gnome-text-editor"),)
+    monkeypatch.setattr(catalog, "launch_entries", lambda: rows)
+    text = catalog.launch_context_text()
+    assert "Launchable apps for launch_app" in text
+    assert "Text Editor => gnome-text-editor" in text

--- a/.test/test_gpt_semantic_launch_provider.py
+++ b/.test/test_gpt_semantic_launch_provider.py
@@ -1,0 +1,32 @@
+import sys
+
+sys.path.append(".")
+
+from GPT.semantic.gpt_semantic_launch_provider import LaunchProvider
+
+
+def test_read_entries_prefers_community(monkeypatch) -> None:
+    provider = LaunchProvider([])
+    monkeypatch.setattr(provider, "_community_entries", lambda: (("B", "2"), ("A", "1")))
+    monkeypatch.setattr(provider, "_desktop_entries", lambda: (("X", "x"),))
+    assert provider.read_entries() == (("B", "2"), ("A", "1"))
+
+
+def test_read_entries_falls_back_to_desktop(monkeypatch) -> None:
+    provider = LaunchProvider([])
+    monkeypatch.setattr(provider, "_community_entries", lambda: ())
+    monkeypatch.setattr(provider, "_desktop_entries", lambda: (("X", "x"),))
+    assert provider.read_entries() == (("X", "x"),)
+
+
+def test_load_community_apps_filters_empty_values(monkeypatch) -> None:
+    provider = LaunchProvider([])
+    monkeypatch.setattr(
+        provider,
+        "_app_getter",
+        lambda: lambda: {"Editor": "gedit", "": "bad", "Term": "", "Calc": "gnome-calculator"},
+    )
+    assert provider._load_community_apps() == {
+        "Editor": "gedit",
+        "Calc": "gnome-calculator",
+    }

--- a/.test/test_gpt_semantic_launch_provider.py
+++ b/.test/test_gpt_semantic_launch_provider.py
@@ -7,7 +7,9 @@ from GPT.semantic.gpt_semantic_launch_provider import LaunchProvider
 
 def test_read_entries_prefers_community(monkeypatch) -> None:
     provider = LaunchProvider([])
-    monkeypatch.setattr(provider, "_community_entries", lambda: (("B", "2"), ("A", "1")))
+    monkeypatch.setattr(
+        provider, "_community_entries", lambda: (("B", "2"), ("A", "1"))
+    )
     monkeypatch.setattr(provider, "_desktop_entries", lambda: (("X", "x"),))
     assert provider.read_entries() == (("B", "2"), ("A", "1"))
 
@@ -24,7 +26,12 @@ def test_load_community_apps_filters_empty_values(monkeypatch) -> None:
     monkeypatch.setattr(
         provider,
         "_app_getter",
-        lambda: lambda: {"Editor": "gedit", "": "bad", "Term": "", "Calc": "gnome-calculator"},
+        lambda: lambda: {
+            "Editor": "gedit",
+            "": "bad",
+            "Term": "",
+            "Calc": "gnome-calculator",
+        },
     )
     assert provider._load_community_apps() == {
         "Editor": "gedit",

--- a/.test/test_gpt_semantic_parser.py
+++ b/.test/test_gpt_semantic_parser.py
@@ -1,0 +1,50 @@
+import sys
+
+sys.path.append(".")
+
+from GPT.semantic.gpt_semantic_parser import GptSemanticParseError, parse_plan
+
+
+def test_parse_valid_plan() -> None:
+    raw = (
+        '{"steps":[{"action":"launch_app","args":{"app_name":"Text Editor"}},'
+        '{"action":"go_url","args":{"url":"https://example.com"}}]}'
+    )
+    plan = parse_plan(raw)
+    assert len(plan.steps) == 2
+    assert plan.steps[0].args["app_name"] == "Text Editor"
+
+
+def test_parse_malformed_json() -> None:
+    try:
+        parse_plan("{")
+        assert False
+    except GptSemanticParseError as exc:
+        assert "not valid JSON" in str(exc)
+
+
+def test_parse_unknown_action() -> None:
+    raw = '{"steps":[{"action":"launch_missiles","args":{}}]}'
+    try:
+        parse_plan(raw)
+        assert False
+    except GptSemanticParseError as exc:
+        assert "unsupported action" in str(exc)
+
+
+def test_parse_bad_arg_type() -> None:
+    raw = '{"steps":[{"action":"sleep","args":{"ms":"200"}}]}'
+    try:
+        parse_plan(raw)
+        assert False
+    except GptSemanticParseError as exc:
+        assert "must be int" in str(exc)
+
+
+def test_parse_rejects_extra_fields() -> None:
+    raw = '{"steps":[{"action":"new_tab","args":{},"extra":true}],"garbage":1}'
+    try:
+        parse_plan(raw)
+        assert False
+    except GptSemanticParseError as exc:
+        assert "unsupported" in str(exc)

--- a/.test/test_gpt_semantic_transport.py
+++ b/.test/test_gpt_semantic_transport.py
@@ -1,0 +1,63 @@
+import sys
+
+sys.path.append(".")
+
+from GPT.semantic import gpt_semantic_transport as transport
+
+
+def test_routes_to_api(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_api(request, system_message, model):
+        calls.append(f"api:{model}:{system_message}:{request['content'][0]['text']}")
+        return {"type": "text", "text": "ok-api"}
+
+    def fake_llm(*_args, **_kwargs):
+        calls.append("llm")
+        return {"type": "text", "text": "ok-llm"}
+
+    monkeypatch.setattr(transport, "_model_endpoint", lambda: "https://example.com")
+    monkeypatch.setattr(
+        transport,
+        "_helpers",
+        lambda: {
+            "resolve_model_name": lambda m: m,
+            "format_message": lambda text: {"type": "text", "text": text},
+            "extract_message": lambda resp: resp["text"],
+            "send_request_to_api": fake_api,
+            "send_request_to_llm_cli": fake_llm,
+        },
+    )
+
+    result = transport.request_completion("sys", "user", "m", debug=False)
+    assert result == "ok-api"
+    assert calls[0].startswith("api:m:sys:user")
+
+
+def test_routes_to_llm(monkeypatch) -> None:
+    calls: list[str] = []
+
+    def fake_api(*_args, **_kwargs):
+        calls.append("api")
+        return {"type": "text", "text": "ok-api"}
+
+    def fake_llm(prompt, _content, system, model, _thread):
+        calls.append(f"llm:{model}:{system}:{prompt['text']}")
+        return {"type": "text", "text": "ok-llm"}
+
+    monkeypatch.setattr(transport, "_model_endpoint", lambda: "llm")
+    monkeypatch.setattr(
+        transport,
+        "_helpers",
+        lambda: {
+            "resolve_model_name": lambda m: f"resolved-{m}",
+            "format_message": lambda text: {"type": "text", "text": text},
+            "extract_message": lambda resp: resp["text"],
+            "send_request_to_api": fake_api,
+            "send_request_to_llm_cli": fake_llm,
+        },
+    )
+
+    result = transport.request_completion("sys", "user", "m", debug=False)
+    assert result == "ok-llm"
+    assert calls[0].startswith("llm:resolved-m:sys:user")

--- a/GPT/readme.md
+++ b/GPT/readme.md
@@ -12,6 +12,39 @@ Query language models with voice commands. Helpful to automatically generate tex
 
 - View the [docs](http://localhost:4321/talon-ai-tools/) for more detailed usage and help
 
+## Semantic Commands
+
+This repo includes a standalone semantic planner under `GPT/semantic/`. It is self-contained and does not depend
+on `user/semantic_commands`.
+
+Voice commands:
+
+- `model semantic <request>`
+- `model semantic run plan`
+- `model semantic cancel plan`
+- `model semantic copy plan`
+- `model semantic repeat last`
+
+Behavior:
+
+- Generates a JSON action plan with strict schema validation.
+- Applies guardrails before preview.
+- Requires explicit confirmation before execution.
+- Stops on first execution failure and keeps the failed plan for inspection.
+
+Configuration settings:
+
+- `user.gpt_semantic_max_steps` (default `12`)
+- `user.gpt_semantic_max_total_sleep_ms` (default `2000`)
+- `user.gpt_semantic_max_insert_chars` (default `500`)
+- `user.gpt_semantic_debug` (default `false`)
+- `user.gpt_semantic_system_prompt` (default built-in strict planner prompt)
+
+Transport:
+
+- Semantic translation reuses the existing AI-tools routing stack in `lib/modelHelpers.py`.
+- It respects `user.model_endpoint` and supports both OpenAI-compatible HTTP and `llm` CLI modes.
+
 ## OpenAI API Pricing
 
 The OpenAI API that is used in this repo, through which you make queries to GPT 3.5 (the model used for ChatGPT), is not free. However it is extremely cheap and unless you are frequently processing large amounts of text, it will likely cost less than $1 per month. Most months I have spent less than $0.50

--- a/GPT/semantic/__init__.py
+++ b/GPT/semantic/__init__.py
@@ -1,0 +1,1 @@
+"""Model semantic command implementation for talon-ai-tools."""

--- a/GPT/semantic/gpt_semantic.talon
+++ b/GPT/semantic/gpt_semantic.talon
@@ -3,10 +3,8 @@ not tag: user.gpt_semantic_preview_open
 
 # Example: `model semantic open text editor`.
 # Generate a semantic plan from natural language.
-{user.model} semantic <user.text>$:
-    user.gpt_semantic_generate(text, model)
+{user.model} semantic <user.text>$: user.gpt_semantic_generate(text, model)
 
 # Example: `model semantic repeat last`.
 # Re-open the last confirmed plan in preview mode.
-{user.model} semantic repeat last$:
-    user.gpt_semantic_repeat_last()
+{user.model} semantic repeat last$: user.gpt_semantic_repeat_last()

--- a/GPT/semantic/gpt_semantic.talon
+++ b/GPT/semantic/gpt_semantic.talon
@@ -1,0 +1,12 @@
+not tag: user.gpt_semantic_preview_open
+-
+
+# Example: `model semantic open text editor`.
+# Generate a semantic plan from natural language.
+{user.model} semantic <user.text>$:
+    user.gpt_semantic_generate(text, model)
+
+# Example: `model semantic repeat last`.
+# Re-open the last confirmed plan in preview mode.
+{user.model} semantic repeat last$:
+    user.gpt_semantic_repeat_last()

--- a/GPT/semantic/gpt_semantic_actions.py
+++ b/GPT/semantic/gpt_semantic_actions.py
@@ -1,0 +1,38 @@
+"""Public Talon actions for semantic planning and execution.
+
+Purpose:
+- Exposes `user.gpt_semantic_*` actions used by Talon voice commands.
+
+Called from:
+- `GPT/semantic/gpt_semantic.talon`
+- `GPT/semantic/gpt_semantic_preview.talon`
+"""
+
+from talon import Module
+
+from .gpt_semantic_runtime import GptSemanticRuntime
+
+mod = Module()
+
+
+@mod.action_class
+class UserActions:
+    def gpt_semantic_generate(text: str, model: str) -> None:
+        """Generate a semantic plan from spoken text and open preview."""
+        GptSemanticRuntime.generate(text, model)
+
+    def gpt_semantic_run_pending() -> None:
+        """Execute the currently previewed semantic plan."""
+        GptSemanticRuntime.run_pending()
+
+    def gpt_semantic_cancel_pending() -> None:
+        """Cancel and discard the currently previewed semantic plan."""
+        GptSemanticRuntime.cancel_pending()
+
+    def gpt_semantic_copy_pending() -> None:
+        """Copy the currently previewed semantic plan JSON to clipboard."""
+        GptSemanticRuntime.copy_pending()
+
+    def gpt_semantic_repeat_last() -> None:
+        """Re-open the last confirmed semantic plan in preview mode."""
+        GptSemanticRuntime.repeat_last()

--- a/GPT/semantic/gpt_semantic_browser.py
+++ b/GPT/semantic/gpt_semantic_browser.py
@@ -34,4 +34,6 @@ def _is_missing_action(exc: Exception, action_name: str) -> bool:
     message = str(exc).lower()
     if action_name not in message:
         return False
-    return "module method is empty" in message or "no context reimplements it" in message
+    return (
+        "module method is empty" in message or "no context reimplements it" in message
+    )

--- a/GPT/semantic/gpt_semantic_browser.py
+++ b/GPT/semantic/gpt_semantic_browser.py
@@ -1,0 +1,37 @@
+"""Browser action compatibility helpers for semantic steps.
+
+Purpose:
+- Wraps browser actions and provides key-based fallbacks when browser modules are missing.
+
+Called from:
+- `GPT/semantic/gpt_semantic_executor.py`
+"""
+
+from typing import Any
+
+
+def call_go_url(runner: Any, url: str) -> None:
+    try:
+        runner.browser.go(url)
+    except Exception as exc:
+        if not _is_missing_action(exc, "browser.go"):
+            raise
+        runner.key("ctrl-l")
+        runner.insert(url)
+        runner.key("enter")
+
+
+def call_focus_address(runner: Any) -> None:
+    try:
+        runner.browser.focus_address()
+    except Exception as exc:
+        if not _is_missing_action(exc, "browser.focus_address"):
+            raise
+        runner.key("ctrl-l")
+
+
+def _is_missing_action(exc: Exception, action_name: str) -> bool:
+    message = str(exc).lower()
+    if action_name not in message:
+        return False
+    return "module method is empty" in message or "no context reimplements it" in message

--- a/GPT/semantic/gpt_semantic_context.py
+++ b/GPT/semantic/gpt_semantic_context.py
@@ -1,0 +1,43 @@
+"""Planner context builder for semantic requests.
+
+Purpose:
+- Collects active window data, running apps, and launchable app catalog context.
+
+Called from:
+- `GPT/semantic/gpt_semantic_runtime.py` during plan generation.
+"""
+
+from talon import actions
+
+try:
+    from talon import ui
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
+    ui = None
+
+from .gpt_semantic_launch_catalog import launch_context_text
+
+
+def semantic_context_text(request_text: str) -> str:
+    return "\n\n".join(
+        [_active_context(), _running_apps_context(), launch_context_text(request_text)]
+    )
+
+
+def _active_context() -> str:
+    try:
+        return actions.user.talon_get_active_context()
+    except Exception:
+        return f"Name: {actions.app.name()}\nTitle: {actions.win.title()}"
+
+
+def _running_apps_context() -> str:
+    names = _running_app_names()
+    if names:
+        return "Running apps for switch_app:\n" + ", ".join(names[:40])
+    return "Running apps for switch_app: unavailable"
+
+
+def _running_app_names() -> list[str]:
+    if ui is None:
+        return []
+    return sorted({app.name for app in ui.apps(background=False) if app.name})

--- a/GPT/semantic/gpt_semantic_executor.py
+++ b/GPT/semantic/gpt_semantic_executor.py
@@ -1,0 +1,30 @@
+"""Semantic plan executor.
+
+Purpose:
+- Exposes the public execution API for semantic plans.
+- Selects a Talon runner and delegates to the step executor implementation.
+
+Called from:
+- `GPT/semantic/gpt_semantic_runtime.py` when running a confirmed plan.
+"""
+
+from typing import Any
+
+try:
+    from talon import actions as talon_actions
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
+    talon_actions = None
+
+from .gpt_semantic_step_executor import GptSemanticExecutionError, GptSemanticStepExecutor
+from .gpt_semantic_types import GptSemanticPlan
+
+
+def execute_plan(plan: GptSemanticPlan, runner: Any = None) -> None:
+    active_runner = runner if runner is not None else _default_runner()
+    GptSemanticStepExecutor(active_runner).run(plan)
+
+
+def _default_runner() -> Any:
+    if talon_actions is None:
+        raise RuntimeError("Talon actions are unavailable")
+    return talon_actions

--- a/GPT/semantic/gpt_semantic_executor.py
+++ b/GPT/semantic/gpt_semantic_executor.py
@@ -15,7 +15,10 @@ try:
 except (ModuleNotFoundError, ImportError):  # pragma: no cover
     talon_actions = None
 
-from .gpt_semantic_step_executor import GptSemanticExecutionError, GptSemanticStepExecutor
+from .gpt_semantic_step_executor import (
+    GptSemanticExecutionError,
+    GptSemanticStepExecutor,
+)
 from .gpt_semantic_types import GptSemanticPlan
 
 

--- a/GPT/semantic/gpt_semantic_executor_helpers.py
+++ b/GPT/semantic/gpt_semantic_executor_helpers.py
@@ -38,7 +38,9 @@ def is_running_app(app_name: str) -> bool:
     if talon_ui is None:
         return True
     target = _normalize_name(app_name)
-    names = [_normalize_name(app.name) for app in talon_ui.apps(background=False) if app.name]
+    names = [
+        _normalize_name(app.name) for app in talon_ui.apps(background=False) if app.name
+    ]
     return any(name == target or target in name or name in target for name in names)
 
 

--- a/GPT/semantic/gpt_semantic_executor_helpers.py
+++ b/GPT/semantic/gpt_semantic_executor_helpers.py
@@ -1,0 +1,58 @@
+"""Helper utilities for semantic step execution.
+
+Purpose:
+- Defines shared action call maps and runtime app/launch resolution helpers.
+
+Called from:
+- `GPT/semantic/gpt_semantic_step_executor.py`.
+"""
+
+try:
+    from talon import ui as talon_ui
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
+    talon_ui = None
+
+from .gpt_semantic_launch_catalog import resolve_launch_command
+
+ARG_CALLS: dict[str, tuple[str | None, str, str]] = {
+    "switch_app": ("user", "switcher_focus", "app_name"),
+    "go_url": ("browser", "go", "url"),
+    "find_text": ("edit", "find", "text"),
+    "insert_text": (None, "insert", "text"),
+    "key": (None, "key", "combo"),
+}
+NO_ARG_CALLS: dict[str, tuple[str, str]] = {
+    "new_tab": ("app", "tab_open"),
+    "copy": ("edit", "copy"),
+    "paste": ("edit", "paste"),
+    "select_all": ("edit", "select_all"),
+    "undo": ("edit", "undo"),
+    "redo": ("edit", "redo"),
+    "line_start": ("edit", "line_start"),
+    "line_end": ("edit", "line_end"),
+    "delete_selection": ("edit", "delete"),
+}
+
+
+def is_running_app(app_name: str) -> bool:
+    if talon_ui is None:
+        return True
+    target = _normalize_name(app_name)
+    names = [_normalize_name(app.name) for app in talon_ui.apps(background=False) if app.name]
+    return any(name == target or target in name or name in target for name in names)
+
+
+def validate_running_app(app_name: str) -> None:
+    if is_running_app(app_name):
+        return
+    raise RuntimeError(f"App not running: '{app_name}'. Open it or use launch_app.")
+
+
+def launch_candidates(app_name: str) -> list[str]:
+    resolved = resolve_launch_command(app_name)
+    return [resolved, app_name] if resolved and resolved != app_name else [app_name]
+
+
+def _normalize_name(value: str) -> str:
+    lowered = value.lower().replace("-", " ").replace("_", " ").strip()
+    return " ".join(lowered.split())

--- a/GPT/semantic/gpt_semantic_guardrails.py
+++ b/GPT/semantic/gpt_semantic_guardrails.py
@@ -61,7 +61,9 @@ def _add_sleep_errors(plan: GptSemanticPlan, max_total: int, errors: list[str]) 
         errors.append(f"Total sleep is {total}ms; maximum is {max_total}ms")
 
 
-def _add_insert_errors(plan: GptSemanticPlan, max_chars: int, errors: list[str]) -> None:
+def _add_insert_errors(
+    plan: GptSemanticPlan, max_chars: int, errors: list[str]
+) -> None:
     for index, step in enumerate(plan.steps, start=1):
         if step.action != "insert_text":
             continue

--- a/GPT/semantic/gpt_semantic_guardrails.py
+++ b/GPT/semantic/gpt_semantic_guardrails.py
@@ -1,0 +1,78 @@
+"""Safety and limit checks for semantic plans.
+
+Purpose:
+- Validates plan size, sleep budget, text insert limits, and blocked key combos.
+
+Called from:
+- `GPT/semantic/gpt_semantic_runtime.py` after parsing model output.
+"""
+
+from __future__ import annotations
+
+from .gpt_semantic_types import GptSemanticPlan
+
+BLOCKED_KEY_COMBOS = {
+    "alt-f4",
+    "ctrl-q",
+    "cmd-q",
+    "ctrl-w",
+    "cmd-w",
+    "super-l",
+    "ctrl-alt-delete",
+    "alt-space c",
+}
+
+
+class GptSemanticGuardrailError(ValueError):
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+def validate_guardrails(
+    plan: GptSemanticPlan,
+    max_steps: int,
+    max_total_sleep_ms: int,
+    max_insert_chars: int,
+) -> None:
+    errors = _collect_errors(plan, max_steps, max_total_sleep_ms, max_insert_chars)
+    if errors:
+        raise GptSemanticGuardrailError(errors)
+
+
+def _collect_errors(
+    plan: GptSemanticPlan,
+    max_steps: int,
+    max_total_sleep_ms: int,
+    max_insert_chars: int,
+) -> list[str]:
+    errors: list[str] = []
+    if len(plan.steps) > max_steps:
+        errors.append(f"Plan has {len(plan.steps)} steps; maximum is {max_steps}")
+    _add_sleep_errors(plan, max_total_sleep_ms, errors)
+    _add_insert_errors(plan, max_insert_chars, errors)
+    _add_key_errors(plan, errors)
+    return errors
+
+
+def _add_sleep_errors(plan: GptSemanticPlan, max_total: int, errors: list[str]) -> None:
+    total = sum(step.args.get("ms", 0) for step in plan.steps if step.action == "sleep")
+    if total > max_total:
+        errors.append(f"Total sleep is {total}ms; maximum is {max_total}ms")
+
+
+def _add_insert_errors(plan: GptSemanticPlan, max_chars: int, errors: list[str]) -> None:
+    for index, step in enumerate(plan.steps, start=1):
+        if step.action != "insert_text":
+            continue
+        if len(str(step.args.get("text", ""))) > max_chars:
+            errors.append(f"Step {index}: insert_text exceeds {max_chars} characters")
+
+
+def _add_key_errors(plan: GptSemanticPlan, errors: list[str]) -> None:
+    for index, step in enumerate(plan.steps, start=1):
+        if step.action != "key":
+            continue
+        combo = " ".join(str(step.args.get("combo", "")).strip().lower().split())
+        if combo in BLOCKED_KEY_COMBOS:
+            errors.append(f"Step {index}: key combo '{combo}' is blocked")

--- a/GPT/semantic/gpt_semantic_gui.py
+++ b/GPT/semantic/gpt_semantic_gui.py
@@ -1,0 +1,75 @@
+"""Semantic plan preview UI.
+
+Purpose:
+- Renders the confirmation window with steps and Run/Copy/Cancel controls.
+- Toggles the preview tag used by preview-only voice commands.
+
+Called from:
+- `GPT/semantic/gpt_semantic_runtime.py` via `show_preview()` / `hide_preview()`.
+"""
+
+import textwrap
+
+from talon import Context, Module, actions, imgui, settings
+
+from .gpt_semantic_state import GptSemanticState
+
+mod = Module()
+ctx = Context()
+
+
+@imgui.open()
+def semantic_preview(gui: imgui.GUI) -> None:
+    _render_header(gui)
+    _render_summary(gui)
+    _render_steps(gui)
+    _render_buttons(gui)
+
+
+def show_preview() -> None:
+    ctx.tags = ["user.gpt_semantic_preview_open"]
+    semantic_preview.show()
+
+
+def hide_preview() -> None:
+    semantic_preview.hide()
+    ctx.tags = []
+
+
+def _render_header(gui: imgui.GUI) -> None:
+    gui.text("Model semantic plan preview")
+    gui.line()
+    if GptSemanticState.pending_request:
+        gui.text(f"Request: {GptSemanticState.pending_request}")
+
+
+def _render_summary(gui: imgui.GUI) -> None:
+    plan = GptSemanticState.pending_plan
+    if plan is None or not plan.summary:
+        return
+    gui.spacer()
+    gui.text(f"Summary: {plan.summary}")
+
+
+def _render_steps(gui: imgui.GUI) -> None:
+    plan = GptSemanticState.pending_plan
+    if plan is None:
+        return
+    gui.spacer()
+    width = settings.get("user.model_window_char_width")
+    for index, step in enumerate(plan.steps, start=1):
+        line = f"{index}. {step.action} {step.args}"
+        for chunk in textwrap.wrap(line, width=width):
+            gui.text(chunk)
+
+
+def _render_buttons(gui: imgui.GUI) -> None:
+    gui.spacer()
+    if gui.button("Run plan"):
+        actions.user.gpt_semantic_run_pending()
+    gui.spacer()
+    if gui.button("Copy plan"):
+        actions.user.gpt_semantic_copy_pending()
+    gui.spacer()
+    if gui.button("Cancel plan"):
+        actions.user.gpt_semantic_cancel_pending()

--- a/GPT/semantic/gpt_semantic_launch_catalog.py
+++ b/GPT/semantic/gpt_semantic_launch_catalog.py
@@ -1,0 +1,58 @@
+"""Launchable app catalog utilities for semantic `launch_app`.
+
+Purpose:
+- Provides public launch catalog APIs used by planner context and executor.
+- Delegates reading and matching to focused helper modules.
+
+Called from:
+- `GPT/semantic/gpt_semantic_context.py` to build planner context.
+- `GPT/semantic/gpt_semantic_executor_helpers.py` to resolve launch commands.
+"""
+
+from functools import lru_cache
+from pathlib import Path
+
+from .gpt_semantic_launch_matcher import LaunchMatcher
+from .gpt_semantic_launch_provider import LaunchProvider
+
+DESKTOP_DIRS = [
+    Path.home() / ".local/share/applications",
+    Path("/usr/share/applications"),
+    Path("/var/lib/flatpak/exports/share/applications"),
+    Path.home() / ".local/share/flatpak/exports/share/applications",
+]
+STOP_WORDS = {
+    "a",
+    "an",
+    "app",
+    "application",
+    "launch",
+    "model",
+    "open",
+    "please",
+    "run",
+    "start",
+    "the",
+}
+
+
+def launch_context_text(query: str = "", limit: int = 300) -> str:
+    entries = _matcher().rank_entries(query, launch_entries(), limit)
+    if not entries:
+        return "Launchable apps for launch_app: unavailable"
+    lines = ["Launchable apps for launch_app (name => command):"]
+    lines.extend(f"- {name} => {command}" for name, command in entries)
+    return "\n".join(lines)
+
+
+def resolve_launch_command(app_name: str) -> str | None:
+    return _matcher().resolve(app_name, launch_entries())
+
+
+@lru_cache(maxsize=1)
+def launch_entries() -> tuple[tuple[str, str], ...]:
+    return LaunchProvider(DESKTOP_DIRS).read_entries()
+
+
+def _matcher() -> LaunchMatcher:
+    return LaunchMatcher(STOP_WORDS)

--- a/GPT/semantic/gpt_semantic_launch_matcher.py
+++ b/GPT/semantic/gpt_semantic_launch_matcher.py
@@ -19,7 +19,9 @@ class LaunchMatcher:
 
     def resolve(self, app_name: str, entries: LaunchEntries) -> str | None:
         target = normalize_text(app_name)
-        return self._resolve_name(target, entries) or self._resolve_command(target, entries)
+        return self._resolve_name(target, entries) or self._resolve_command(
+            target, entries
+        )
 
     def rank_entries(
         self, query: str, entries: LaunchEntries, limit: int
@@ -30,7 +32,9 @@ class LaunchMatcher:
 
     def _resolve_name(self, target: str, entries: LaunchEntries) -> str | None:
         for name, command in entries:
-            if normalize_text(name) == target or (target and target in normalize_text(name)):
+            if normalize_text(name) == target or (
+                target and target in normalize_text(name)
+            ):
                 return command
         return None
 
@@ -64,5 +68,9 @@ class LaunchMatcher:
         return 0
 
     def _token_score(self, target: str, name_key: str, command_key: str) -> int:
-        tokens = [token for token in target.split() if token not in self.stop_words and len(token) > 1]
+        tokens = [
+            token
+            for token in target.split()
+            if token not in self.stop_words and len(token) > 1
+        ]
         return sum(1 for token in tokens if token in name_key or token in command_key)

--- a/GPT/semantic/gpt_semantic_launch_matcher.py
+++ b/GPT/semantic/gpt_semantic_launch_matcher.py
@@ -1,0 +1,68 @@
+"""Launch entry ranking and command resolution helpers.
+
+Purpose:
+- Resolves spoken app names to launch commands.
+- Ranks launch catalog entries by request relevance.
+
+Called from:
+- `GPT/semantic/gpt_semantic_launch_catalog.py`.
+"""
+
+from .gpt_semantic_launch_text import command_name, normalize_text
+
+LaunchEntries = tuple[tuple[str, str], ...]
+
+
+class LaunchMatcher:
+    def __init__(self, stop_words: set[str]):
+        self.stop_words = stop_words
+
+    def resolve(self, app_name: str, entries: LaunchEntries) -> str | None:
+        target = normalize_text(app_name)
+        return self._resolve_name(target, entries) or self._resolve_command(target, entries)
+
+    def rank_entries(
+        self, query: str, entries: LaunchEntries, limit: int
+    ) -> list[tuple[str, str]]:
+        if not query.strip():
+            return list(entries[:limit])
+        return self._rank_with_query(query, entries, limit)
+
+    def _resolve_name(self, target: str, entries: LaunchEntries) -> str | None:
+        for name, command in entries:
+            if normalize_text(name) == target or (target and target in normalize_text(name)):
+                return command
+        return None
+
+    def _resolve_command(self, target: str, entries: LaunchEntries) -> str | None:
+        for _, command in entries:
+            if command_name(command) == target:
+                return command
+        return None
+
+    def _rank_with_query(
+        self, query: str, entries: LaunchEntries, limit: int
+    ) -> list[tuple[str, str]]:
+        scored = [(*row, self._score(query, *row)) for row in entries]
+        scored.sort(key=lambda row: (-row[2], row[0].lower()))
+        return [(name, command) for name, command, _ in scored[:limit]]
+
+    def _score(self, query: str, name: str, command: str) -> int:
+        target = normalize_text(query)
+        if not target:
+            return 0
+        name_key = normalize_text(name)
+        command_key = command_name(command)
+        score = self._base_score(target, name_key, command_key)
+        return score + self._token_score(target, name_key, command_key)
+
+    def _base_score(self, target: str, name_key: str, command_key: str) -> int:
+        if target == name_key or target == command_key:
+            return 10
+        if target in name_key or target in command_key:
+            return 5
+        return 0
+
+    def _token_score(self, target: str, name_key: str, command_key: str) -> int:
+        tokens = [token for token in target.split() if token not in self.stop_words and len(token) > 1]
+        return sum(1 for token in tokens if token in name_key or token in command_key)

--- a/GPT/semantic/gpt_semantic_launch_provider.py
+++ b/GPT/semantic/gpt_semantic_launch_provider.py
@@ -1,0 +1,68 @@
+"""Launch entry provider that prefers community app_switcher data.
+
+Purpose:
+- Reuses community app switcher `get_apps()` for cross-platform launch discovery.
+- Falls back to semantic desktop entry reader when community data is unavailable.
+
+Called from:
+- `GPT/semantic/gpt_semantic_launch_catalog.py`.
+"""
+
+from pathlib import Path
+from typing import Callable
+
+from .gpt_semantic_launch_reader import DesktopEntryReader
+
+LaunchEntries = tuple[tuple[str, str], ...]
+
+
+class LaunchProvider:
+    def __init__(self, desktop_dirs: list[Path]):
+        self.desktop_dirs = desktop_dirs
+
+    def read_entries(self) -> LaunchEntries:
+        return self._community_entries() or self._desktop_entries()
+
+    def _community_entries(self) -> LaunchEntries:
+        apps = self._load_community_apps()
+        if not apps:
+            return ()
+        rows = sorted(apps.items(), key=lambda item: item[0].lower())
+        return tuple(rows)
+
+    def _desktop_entries(self) -> LaunchEntries:
+        return DesktopEntryReader(self.desktop_dirs).read_entries()
+
+    def _load_community_apps(self) -> dict[str, str]:
+        getter = self._app_getter()
+        if getter is None:
+            return {}
+        try:
+            apps = getter()
+        except Exception:
+            return {}
+        if not isinstance(apps, dict):
+            return {}
+        return {
+            str(name): str(command)
+            for name, command in apps.items()
+            if str(name).strip() and str(command).strip()
+        }
+
+    def _app_getter(self) -> Callable[[], dict[str, str]] | None:
+        module = self._import_switcher_module()
+        getter = getattr(module, "get_apps", None) if module is not None else None
+        return getter if callable(getter) else None
+
+    def _import_switcher_module(self) -> object | None:
+        names = [
+            "user.community.core.app_switcher.app_switcher",
+            "community.core.app_switcher.app_switcher",
+        ]
+        for name in names:
+            try:
+                module = __import__(name, fromlist=["get_apps"])
+                return module
+            except Exception:
+                continue
+        return None

--- a/GPT/semantic/gpt_semantic_launch_reader.py
+++ b/GPT/semantic/gpt_semantic_launch_reader.py
@@ -1,0 +1,84 @@
+"""Desktop entry reader for launchable app catalog.
+
+Purpose:
+- Scans .desktop files and extracts normalized executable launch entries.
+
+Called from:
+- `GPT/semantic/gpt_semantic_launch_catalog.py`.
+"""
+
+from configparser import ConfigParser
+from pathlib import Path
+from shutil import which
+from shlex import split
+
+LaunchEntries = tuple[tuple[str, str], ...]
+
+
+class DesktopEntryReader:
+    def __init__(self, directories: list[Path]):
+        self.directories = directories
+
+    def read_entries(self) -> LaunchEntries:
+        merged: dict[str, str] = {}
+        for file_path in self._desktop_files():
+            parsed = self._parse_file(file_path)
+            if parsed is not None:
+                merged.setdefault(*parsed)
+        return tuple(sorted(merged.items(), key=lambda item: item[0].lower()))
+
+    def _desktop_files(self) -> list[Path]:
+        files: list[Path] = []
+        for directory in self.directories:
+            if directory.exists():
+                files.extend(directory.glob("*.desktop"))
+        return files
+
+    def _parse_file(self, file_path: Path) -> tuple[str, str] | None:
+        parser = self._read_parser(file_path)
+        if parser is None or not self._is_valid_entry(parser):
+            return None
+        return self._entry_values(parser)
+
+    def _read_parser(self, file_path: Path) -> ConfigParser | None:
+        parser = ConfigParser(interpolation=None, strict=False)
+        try:
+            parser.read(file_path, encoding="utf-8")
+        except Exception:
+            return None
+        return parser
+
+    def _is_valid_entry(self, parser: ConfigParser) -> bool:
+        if parser.get("Desktop Entry", "Type", fallback="") != "Application":
+            return False
+        return parser.get("Desktop Entry", "NoDisplay", fallback="false").lower() != "true"
+
+    def _entry_values(self, parser: ConfigParser) -> tuple[str, str] | None:
+        name = parser.get("Desktop Entry", "Name", fallback="").strip()
+        command = self._canonical_exec(self._clean_exec(parser.get("Desktop Entry", "Exec", fallback="")))
+        if not name or not command or self._looks_like_web_shortcut(name, command):
+            return None
+        return name, command
+
+    def _clean_exec(self, exec_line: str) -> str:
+        parts = [part for part in split(exec_line) if not part.startswith("%")]
+        return " ".join(parts).strip()
+
+    def _canonical_exec(self, command: str) -> str:
+        parts = split(command) if command else []
+        if not parts:
+            return ""
+        resolved = self._resolve_executable(parts[0])
+        if resolved is None:
+            return ""
+        parts[0] = resolved
+        return " ".join(parts)
+
+    def _resolve_executable(self, command: str) -> str | None:
+        if command.startswith("/") and Path(command).is_file():
+            return command
+        return which(command)
+
+    def _looks_like_web_shortcut(self, name: str, command: str) -> bool:
+        combined = f"{name}\n{command}".lower()
+        return "http://" in combined or "https://" in combined

--- a/GPT/semantic/gpt_semantic_launch_reader.py
+++ b/GPT/semantic/gpt_semantic_launch_reader.py
@@ -9,8 +9,8 @@ Called from:
 
 from configparser import ConfigParser
 from pathlib import Path
-from shutil import which
 from shlex import split
+from shutil import which
 
 LaunchEntries = tuple[tuple[str, str], ...]
 
@@ -51,11 +51,15 @@ class DesktopEntryReader:
     def _is_valid_entry(self, parser: ConfigParser) -> bool:
         if parser.get("Desktop Entry", "Type", fallback="") != "Application":
             return False
-        return parser.get("Desktop Entry", "NoDisplay", fallback="false").lower() != "true"
+        return (
+            parser.get("Desktop Entry", "NoDisplay", fallback="false").lower() != "true"
+        )
 
     def _entry_values(self, parser: ConfigParser) -> tuple[str, str] | None:
         name = parser.get("Desktop Entry", "Name", fallback="").strip()
-        command = self._canonical_exec(self._clean_exec(parser.get("Desktop Entry", "Exec", fallback="")))
+        command = self._canonical_exec(
+            self._clean_exec(parser.get("Desktop Entry", "Exec", fallback=""))
+        )
         if not name or not command or self._looks_like_web_shortcut(name, command):
             return None
         return name, command

--- a/GPT/semantic/gpt_semantic_launch_text.py
+++ b/GPT/semantic/gpt_semantic_launch_text.py
@@ -1,0 +1,34 @@
+"""Text normalization helpers for semantic launch catalog logic.
+
+Purpose:
+- Normalizes app names and commands for matching and ranking.
+
+Called from:
+- `GPT/semantic/gpt_semantic_launch_matcher.py`
+- `GPT/semantic/gpt_semantic_launch_reader.py`
+"""
+
+from shlex import split
+
+
+def normalize_text(value: str) -> str:
+    words = value.strip().lower().replace("-", " ").split()
+    return " ".join(words)
+
+
+def first_token(command: str) -> str:
+    if not command:
+        return ""
+    return _split_parts(command)[0]
+
+
+def command_name(command: str) -> str:
+    return normalize_text(first_token(command))
+
+
+def _split_parts(command: str) -> list[str]:
+    try:
+        parts = split(command)
+    except ValueError:
+        parts = command.strip().split()
+    return parts if parts else [""]

--- a/GPT/semantic/gpt_semantic_module.py
+++ b/GPT/semantic/gpt_semantic_module.py
@@ -1,0 +1,61 @@
+"""Talon module declarations for semantic commands.
+
+Purpose:
+- Registers semantic tag and settings used by runtime, parser, and executor.
+
+Called from:
+- Loaded automatically by Talon at startup/import time.
+"""
+
+from talon import Module
+
+from .gpt_semantic_prompt import DEFAULT_SYSTEM_PROMPT
+
+mod = Module()
+mod.tag(
+    "gpt_semantic_preview_open",
+    desc="Enable model semantic run/cancel/copy commands while preview is visible",
+)
+
+mod.setting(
+    "gpt_semantic_max_steps",
+    type=int,
+    default=12,
+    desc="Maximum semantic plan step count",
+)
+mod.setting(
+    "gpt_semantic_max_total_sleep_ms",
+    type=int,
+    default=2000,
+    desc="Maximum total sleep duration for semantic plans",
+)
+mod.setting(
+    "gpt_semantic_max_insert_chars",
+    type=int,
+    default=500,
+    desc="Maximum insert_text payload length in semantic plans",
+)
+mod.setting(
+    "gpt_semantic_debug",
+    type=bool,
+    default=False,
+    desc="Enable debug logging for model semantic internals",
+)
+mod.setting(
+    "gpt_semantic_app_focus_timeout_ms",
+    type=int,
+    default=3500,
+    desc="Maximum wait for app focus after launch_app/switch_app steps",
+)
+mod.setting(
+    "gpt_semantic_step_settle_ms",
+    type=int,
+    default=180,
+    desc="Small delay after UI-sensitive steps to reduce race conditions",
+)
+mod.setting(
+    "gpt_semantic_system_prompt",
+    type=str,
+    default=DEFAULT_SYSTEM_PROMPT,
+    desc="System prompt used for model semantic translation",
+)

--- a/GPT/semantic/gpt_semantic_parser.py
+++ b/GPT/semantic/gpt_semantic_parser.py
@@ -1,0 +1,108 @@
+"""Strict JSON parser and schema validator for semantic plans.
+
+Purpose:
+- Parses model output into typed plan objects.
+- Rejects unknown actions, bad args, and extra fields.
+
+Called from:
+- `GPT/semantic/gpt_semantic_runtime.py` before guardrail validation.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from .gpt_semantic_types import ACTION_ARG_SPECS, GptSemanticPlan, GptSemanticStep
+
+
+class GptSemanticParseError(ValueError):
+    def __init__(self, errors: list[str]):
+        self.errors = errors
+        super().__init__("; ".join(errors))
+
+
+def parse_plan(raw_response: str) -> GptSemanticPlan:
+    errors: list[str] = []
+    payload = _load_json(raw_response, errors)
+    if payload is None:
+        raise GptSemanticParseError(errors)
+    steps = _parse_steps(payload, errors)
+    summary = payload.get("summary")
+    if summary is not None and not isinstance(summary, str):
+        errors.append("Root field 'summary' must be a string")
+        summary = None
+    if errors:
+        raise GptSemanticParseError(errors)
+    return GptSemanticPlan(steps=steps, summary=summary)
+
+
+def _load_json(raw: str, errors: list[str]) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        errors.append(f"Response is not valid JSON: {exc}")
+        return None
+    if not isinstance(payload, dict):
+        errors.append("Root must be an object")
+        return None
+    extras = sorted(set(payload) - {"steps", "summary"})
+    if extras:
+        errors.append(f"Root unsupported fields: {', '.join(extras)}")
+    return payload
+
+
+def _parse_steps(payload: dict[str, Any], errors: list[str]) -> list[GptSemanticStep]:
+    raw_steps = payload.get("steps")
+    if not isinstance(raw_steps, list):
+        errors.append("Root field 'steps' must be a list")
+        return []
+    parsed = [_parse_step(i + 1, raw, errors) for i, raw in enumerate(raw_steps)]
+    return [step for step in parsed if step]
+
+
+def _parse_step(index: int, raw: Any, errors: list[str]) -> GptSemanticStep | None:
+    if not isinstance(raw, dict):
+        errors.append(f"Step {index}: must be an object")
+        return None
+    _validate_step_keys(index, raw, errors)
+    action = raw.get("action")
+    args = raw.get("args")
+    if not isinstance(action, str):
+        errors.append(f"Step {index}: 'action' must be a string")
+        return None
+    if action not in ACTION_ARG_SPECS:
+        errors.append(f"Step {index}: unsupported action '{action}'")
+        return None
+    if not isinstance(args, dict):
+        errors.append(f"Step {index}: 'args' must be an object")
+        return None
+    _validate_args(index, action, args, errors)
+    return GptSemanticStep(action=action, args=args)
+
+
+def _validate_step_keys(index: int, step: dict[str, Any], errors: list[str]) -> None:
+    missing = sorted({"action", "args"} - set(step))
+    extras = sorted(set(step) - {"action", "args"})
+    if missing:
+        errors.append(f"Step {index}: missing fields: {', '.join(missing)}")
+    if extras:
+        errors.append(f"Step {index}: unsupported fields: {', '.join(extras)}")
+
+
+def _validate_args(index: int, action: str, args: dict[str, Any], errors: list[str]) -> None:
+    spec = ACTION_ARG_SPECS[action]
+    missing = sorted(set(spec) - set(args))
+    extras = sorted(set(args) - set(spec))
+    if missing:
+        errors.append(f"Step {index}: missing args: {', '.join(missing)}")
+    if extras:
+        errors.append(f"Step {index}: unsupported args: {', '.join(extras)}")
+    for key, expected in spec.items():
+        value = args.get(key)
+        if value is not None and not _matches_type(value, expected):
+            errors.append(f"Step {index}: arg '{key}' must be {expected.__name__}")
+
+
+def _matches_type(value: Any, expected: type) -> bool:
+    return not (expected is int and isinstance(value, bool)) and isinstance(value, expected)

--- a/GPT/semantic/gpt_semantic_parser.py
+++ b/GPT/semantic/gpt_semantic_parser.py
@@ -90,7 +90,9 @@ def _validate_step_keys(index: int, step: dict[str, Any], errors: list[str]) -> 
         errors.append(f"Step {index}: unsupported fields: {', '.join(extras)}")
 
 
-def _validate_args(index: int, action: str, args: dict[str, Any], errors: list[str]) -> None:
+def _validate_args(
+    index: int, action: str, args: dict[str, Any], errors: list[str]
+) -> None:
     spec = ACTION_ARG_SPECS[action]
     missing = sorted(set(spec) - set(args))
     extras = sorted(set(args) - set(spec))
@@ -105,4 +107,6 @@ def _validate_args(index: int, action: str, args: dict[str, Any], errors: list[s
 
 
 def _matches_type(value: Any, expected: type) -> bool:
-    return not (expected is int and isinstance(value, bool)) and isinstance(value, expected)
+    return not (expected is int and isinstance(value, bool)) and isinstance(
+        value, expected
+    )

--- a/GPT/semantic/gpt_semantic_preview.talon
+++ b/GPT/semantic/gpt_semantic_preview.talon
@@ -1,0 +1,17 @@
+tag: user.gpt_semantic_preview_open
+-
+
+# Example: `model semantic run plan`.
+# Execute the currently previewed semantic plan.
+{user.model} semantic run plan$:
+    user.gpt_semantic_run_pending()
+
+# Example: `model semantic cancel plan`.
+# Discard the currently previewed semantic plan.
+{user.model} semantic cancel plan$:
+    user.gpt_semantic_cancel_pending()
+
+# Example: `model semantic copy plan`.
+# Copy the currently previewed semantic JSON plan.
+{user.model} semantic copy plan$:
+    user.gpt_semantic_copy_pending()

--- a/GPT/semantic/gpt_semantic_preview.talon
+++ b/GPT/semantic/gpt_semantic_preview.talon
@@ -3,15 +3,12 @@ tag: user.gpt_semantic_preview_open
 
 # Example: `model semantic run plan`.
 # Execute the currently previewed semantic plan.
-{user.model} semantic run plan$:
-    user.gpt_semantic_run_pending()
+{user.model} semantic run plan$: user.gpt_semantic_run_pending()
 
 # Example: `model semantic cancel plan`.
 # Discard the currently previewed semantic plan.
-{user.model} semantic cancel plan$:
-    user.gpt_semantic_cancel_pending()
+{user.model} semantic cancel plan$: user.gpt_semantic_cancel_pending()
 
 # Example: `model semantic copy plan`.
 # Copy the currently previewed semantic JSON plan.
-{user.model} semantic copy plan$:
-    user.gpt_semantic_copy_pending()
+{user.model} semantic copy plan$: user.gpt_semantic_copy_pending()

--- a/GPT/semantic/gpt_semantic_prompt.py
+++ b/GPT/semantic/gpt_semantic_prompt.py
@@ -1,0 +1,64 @@
+"""Prompt builders for semantic planning and one-shot repair.
+
+Purpose:
+- Defines default system prompt, schema text, and rules for model outputs.
+- Builds initial and repair prompts with runtime context.
+
+Called from:
+- `GPT/semantic/gpt_semantic_runtime.py` during plan generation.
+"""
+
+from .gpt_semantic_types import ACTION_ARG_SPECS, ALLOWED_ACTIONS
+
+DEFAULT_SYSTEM_PROMPT = (
+    "You translate natural-language desktop requests into a strictly valid JSON action plan. "
+    "Return only JSON. Never include markdown, prose, or code fences. "
+    "Use only non-destructive actions and prefer the smallest plan that satisfies the request."
+)
+
+
+def build_schema_text() -> str:
+    lines = ['{"steps":[{"action":"...", "args":{...}}], "summary":"optional"}']
+    lines.extend(f"- {name}({', '.join(_arg_parts(name))})" for name in ALLOWED_ACTIONS)
+    return "\n".join(lines)
+
+
+def build_user_prompt(request_text: str, active_context: str) -> str:
+    parts = [
+        f"Active context:\n{active_context}",
+        f"Allowed schema:\n{build_schema_text()}",
+        _rules_text(),
+        f'User request:\n"{request_text}"',
+    ]
+    return "\n\n".join(parts)
+
+
+def build_repair_prompt(previous_response: str, errors: list[str]) -> str:
+    error_lines = "\n".join(f"- {error}" for error in errors)
+    parts = [
+        "Your last response failed schema validation.",
+        f"Validation errors:\n{error_lines}",
+        f"Previous response:\n{previous_response}",
+        "Return corrected JSON only.",
+    ]
+    return "\n\n".join(parts)
+
+
+def _arg_parts(action: str) -> list[str]:
+    spec = ACTION_ARG_SPECS[action]
+    return [f"{key}:{kind.__name__}" for key, kind in spec.items()]
+
+
+def _rules_text() -> str:
+    lines = [
+        "Rules:",
+        "- Root keys allowed: steps, summary",
+        "- Step keys allowed: action, args",
+        "- No destructive/system power/quit/close shortcuts",
+        "- switch_app must use app names listed in running apps context",
+        "- launch_app.args.app_name must be exactly one command from launchable apps context",
+        "- Use executable commands from context, not capitalized product names",
+        "- If a requested app name is colloquial, map it to the closest launchable command by function",
+        "- Keep steps concise and deterministic",
+    ]
+    return "\n".join(lines)

--- a/GPT/semantic/gpt_semantic_runtime.py
+++ b/GPT/semantic/gpt_semantic_runtime.py
@@ -82,12 +82,16 @@ class GptSemanticRuntime:
     def _translate_request(text: str, model: str) -> GptSemanticPlan:
         debug = settings.get("user.gpt_semantic_debug")
         prompt = build_user_prompt(text, semantic_context_text(text))
-        raw = request_completion(settings.get("user.gpt_semantic_system_prompt"), prompt, model, debug)
+        raw = request_completion(
+            settings.get("user.gpt_semantic_system_prompt"), prompt, model, debug
+        )
         try:
             return GptSemanticRuntime._parse_and_validate(raw)
         except GptSemanticParseError as exc:
             repair = build_repair_prompt(raw, exc.errors)
-            fixed = request_completion(settings.get("user.gpt_semantic_system_prompt"), repair, model, debug)
+            fixed = request_completion(
+                settings.get("user.gpt_semantic_system_prompt"), repair, model, debug
+            )
             return GptSemanticRuntime._parse_and_validate(fixed)
 
     @staticmethod

--- a/GPT/semantic/gpt_semantic_runtime.py
+++ b/GPT/semantic/gpt_semantic_runtime.py
@@ -1,0 +1,108 @@
+"""Semantic runtime orchestration.
+
+Purpose:
+- Coordinates translation, parse/guardrail validation, preview state, and execution.
+- Handles retry-on-parse-failure and user notifications.
+
+Called from:
+- `GPT/semantic/gpt_semantic_actions.py` action entry points.
+"""
+
+from talon import actions, clip, settings
+
+from .gpt_semantic_context import semantic_context_text
+from .gpt_semantic_executor import GptSemanticExecutionError, execute_plan
+from .gpt_semantic_guardrails import validate_guardrails
+from .gpt_semantic_gui import hide_preview, show_preview
+from .gpt_semantic_parser import GptSemanticParseError, parse_plan
+from .gpt_semantic_prompt import build_repair_prompt, build_user_prompt
+from .gpt_semantic_state import GptSemanticState
+from .gpt_semantic_transport import request_completion
+from .gpt_semantic_types import GptSemanticPlan, plan_to_json
+
+
+class GptSemanticRuntime:
+    @staticmethod
+    def generate(text: str, model: str) -> None:
+        if not text.strip():
+            return GptSemanticRuntime._notify("Semantic command is empty")
+        try:
+            count = GptSemanticRuntime._translate_and_store(text, model)
+            GptSemanticRuntime._notify(f"Semantic plan ready: {count} steps")
+        except Exception as exc:
+            GptSemanticState.set_error(str(exc))
+            GptSemanticRuntime._notify(f"Semantic planning failed: {exc}")
+
+    @staticmethod
+    def run_pending() -> None:
+        plan = GptSemanticState.pending_plan
+        if plan is None:
+            return GptSemanticRuntime._notify("No semantic plan to run")
+        try:
+            execute_plan(plan)
+            GptSemanticState.confirm_pending()
+            GptSemanticState.clear_pending()
+            hide_preview()
+            GptSemanticRuntime._notify("Semantic plan completed")
+        except GptSemanticExecutionError as exc:
+            GptSemanticState.set_error(str(exc))
+            GptSemanticRuntime._notify(f"Semantic execution failed: {exc}")
+
+    @staticmethod
+    def cancel_pending() -> None:
+        hide_preview()
+        GptSemanticState.clear_pending()
+        GptSemanticRuntime._notify("Semantic plan canceled")
+
+    @staticmethod
+    def copy_pending() -> None:
+        if not GptSemanticState.pending_plan_json:
+            return GptSemanticRuntime._notify("No semantic plan to copy")
+        clip.set_text(GptSemanticState.pending_plan_json)
+        GptSemanticRuntime._notify("Semantic plan copied")
+
+    @staticmethod
+    def repeat_last() -> None:
+        plan = GptSemanticState.last_confirmed_plan
+        plan_json = GptSemanticState.last_confirmed_plan_json
+        if plan is None or plan_json is None:
+            return GptSemanticRuntime._notify("No last semantic plan to repeat")
+        GptSemanticState.set_pending("Repeat last confirmed plan", plan, plan_json)
+        show_preview()
+
+    @staticmethod
+    def _translate_and_store(text: str, model: str) -> int:
+        plan = GptSemanticRuntime._translate_request(text, model)
+        plan_json = plan_to_json(plan)
+        GptSemanticState.set_pending(text, plan, plan_json)
+        show_preview()
+        return len(plan.steps)
+
+    @staticmethod
+    def _translate_request(text: str, model: str) -> GptSemanticPlan:
+        debug = settings.get("user.gpt_semantic_debug")
+        prompt = build_user_prompt(text, semantic_context_text(text))
+        raw = request_completion(settings.get("user.gpt_semantic_system_prompt"), prompt, model, debug)
+        try:
+            return GptSemanticRuntime._parse_and_validate(raw)
+        except GptSemanticParseError as exc:
+            repair = build_repair_prompt(raw, exc.errors)
+            fixed = request_completion(settings.get("user.gpt_semantic_system_prompt"), repair, model, debug)
+            return GptSemanticRuntime._parse_and_validate(fixed)
+
+    @staticmethod
+    def _parse_and_validate(raw: str) -> GptSemanticPlan:
+        plan = parse_plan(raw)
+        validate_guardrails(
+            plan,
+            settings.get("user.gpt_semantic_max_steps"),
+            settings.get("user.gpt_semantic_max_total_sleep_ms"),
+            settings.get("user.gpt_semantic_max_insert_chars"),
+        )
+        return plan
+
+    @staticmethod
+    def _notify(message: str) -> None:
+        actions.app.notify(message)
+        if settings.get("user.gpt_semantic_debug"):
+            print(message)

--- a/GPT/semantic/gpt_semantic_state.py
+++ b/GPT/semantic/gpt_semantic_state.py
@@ -1,0 +1,44 @@
+"""In-memory semantic state container.
+
+Purpose:
+- Stores pending plan, last confirmed plan, and last error for the current session.
+
+Called from:
+- `GPT/semantic/gpt_semantic_runtime.py`
+- `GPT/semantic/gpt_semantic_gui.py`
+"""
+
+from .gpt_semantic_types import GptSemanticPlan
+
+
+class GptSemanticState:
+    pending_request: str | None = None
+    pending_plan: GptSemanticPlan | None = None
+    pending_plan_json: str | None = None
+    last_confirmed_plan: GptSemanticPlan | None = None
+    last_confirmed_plan_json: str | None = None
+    last_error: str | None = None
+
+    @classmethod
+    def set_pending(cls, request: str, plan: GptSemanticPlan, plan_json: str) -> None:
+        cls.pending_request = request
+        cls.pending_plan = plan
+        cls.pending_plan_json = plan_json
+        cls.last_error = None
+
+    @classmethod
+    def clear_pending(cls) -> None:
+        cls.pending_request = None
+        cls.pending_plan = None
+        cls.pending_plan_json = None
+
+    @classmethod
+    def confirm_pending(cls) -> None:
+        if cls.pending_plan is None or cls.pending_plan_json is None:
+            return
+        cls.last_confirmed_plan = cls.pending_plan
+        cls.last_confirmed_plan_json = cls.pending_plan_json
+
+    @classmethod
+    def set_error(cls, message: str) -> None:
+        cls.last_error = message

--- a/GPT/semantic/gpt_semantic_step_executor.py
+++ b/GPT/semantic/gpt_semantic_step_executor.py
@@ -1,0 +1,99 @@
+"""Internal step-by-step semantic executor.
+
+Purpose:
+- Executes parsed steps against Talon actions with synchronization and fallbacks.
+- Raises a step-indexed error on the first failed action.
+
+Called from:
+- `GPT/semantic/gpt_semantic_executor.py`.
+"""
+
+from typing import Any
+
+from .gpt_semantic_browser import call_focus_address, call_go_url
+from .gpt_semantic_executor_helpers import (
+    ARG_CALLS,
+    NO_ARG_CALLS,
+    is_running_app,
+    launch_candidates,
+    validate_running_app,
+)
+from .gpt_semantic_sync import settle_after_step, wait_for_app_focus
+from .gpt_semantic_types import GptSemanticPlan, GptSemanticStep
+
+
+class GptSemanticExecutionError(RuntimeError):
+    def __init__(self, step_index: int, action_name: str, error: Exception):
+        self.step_index = step_index
+        self.action_name = action_name
+        super().__init__(f"Step {step_index} ({action_name}) failed: {error}")
+
+
+class GptSemanticStepExecutor:
+    def __init__(self, runner: Any):
+        self.runner = runner
+
+    def run(self, plan: GptSemanticPlan) -> None:
+        for index, step in enumerate(plan.steps, start=1):
+            self._run_step(index, step)
+
+    def _run_step(self, index: int, step: GptSemanticStep) -> None:
+        try:
+            self._dispatch(step)
+            settle_after_step(step.action, self.runner)
+        except Exception as exc:
+            raise GptSemanticExecutionError(index, step.action, exc) from exc
+
+    def _dispatch(self, step: GptSemanticStep) -> None:
+        if self._dispatch_special(step):
+            return
+        if step.action in ARG_CALLS:
+            return self._call_with_arg(step)
+        self._call_no_arg(step)
+
+    def _dispatch_special(self, step: GptSemanticStep) -> bool:
+        if step.action == "sleep":
+            self.runner.sleep(f"{step.args['ms']}ms")
+            return True
+        if step.action == "focus_address":
+            call_focus_address(self.runner)
+            return True
+        if step.action == "switch_app":
+            self._switch_app(str(step.args["app_name"]))
+            return True
+        if step.action == "launch_app":
+            self._launch_app(str(step.args["app_name"]))
+            return True
+        return False
+
+    def _switch_app(self, app_name: str) -> None:
+        if not is_running_app(app_name):
+            return self._launch_app(app_name)
+        validate_running_app(app_name)
+        self.runner.user.switcher_focus(app_name)
+        wait_for_app_focus(self.runner, app_name)
+
+    def _call_with_arg(self, step: GptSemanticStep) -> None:
+        parent, method, arg_name = ARG_CALLS[step.action]
+        value = step.args[arg_name]
+        if step.action == "go_url":
+            return call_go_url(self.runner, str(value))
+        getattr(self._target(parent), method)(value)
+
+    def _call_no_arg(self, step: GptSemanticStep) -> None:
+        parent, method = NO_ARG_CALLS[step.action]
+        getattr(self._target(parent), method)()
+
+    def _target(self, parent: str | None) -> Any:
+        return getattr(self.runner, parent) if parent else self.runner
+
+    def _launch_app(self, app_name: str) -> None:
+        last_error: Exception | None = None
+        for candidate in launch_candidates(app_name):
+            try:
+                self.runner.user.switcher_launch(candidate)
+                wait_for_app_focus(self.runner, app_name, candidate)
+                return
+            except Exception as exc:
+                last_error = exc
+        raise last_error or RuntimeError(f"Unable to launch app: '{app_name}'")

--- a/GPT/semantic/gpt_semantic_sync.py
+++ b/GPT/semantic/gpt_semantic_sync.py
@@ -13,7 +13,8 @@ from shlex import split
 from typing import Any
 
 try:
-    from talon import settings as talon_settings, ui as talon_ui
+    from talon import settings as talon_settings
+    from talon import ui as talon_ui
 except (ModuleNotFoundError, ImportError):  # pragma: no cover
     talon_settings = None
     talon_ui = None
@@ -53,7 +54,9 @@ def _active_app_matches(hints: list[str]) -> bool:
 
 
 def _name_matches(current: str, hint: str) -> bool:
-    return bool(current and hint and (current == hint or hint in current or current in hint))
+    return bool(
+        current and hint and (current == hint or hint in current or current in hint)
+    )
 
 
 def _focus_hints(app_name: str, command: str | None) -> list[str]:

--- a/GPT/semantic/gpt_semantic_sync.py
+++ b/GPT/semantic/gpt_semantic_sync.py
@@ -1,0 +1,91 @@
+"""Execution synchronization helpers for semantic steps.
+
+Purpose:
+- Waits for app focus after launch/switch and adds small settle delays between UI-sensitive steps.
+
+Called from:
+- `GPT/semantic/gpt_semantic_executor.py` during step execution.
+"""
+
+import time
+from pathlib import Path
+from shlex import split
+from typing import Any
+
+try:
+    from talon import settings as talon_settings, ui as talon_ui
+except (ModuleNotFoundError, ImportError):  # pragma: no cover
+    talon_settings = None
+    talon_ui = None
+
+SETTLE_ACTIONS = {"launch_app", "switch_app", "new_tab", "focus_address", "go_url"}
+POLL_INTERVAL_MS = 100
+
+
+def wait_for_app_focus(runner: Any, app_name: str, command: str | None = None) -> None:
+    timeout_ms = _int_setting("user.gpt_semantic_app_focus_timeout_ms", 3500)
+    if talon_ui is None or timeout_ms <= 0:
+        return
+    hints = _focus_hints(app_name, command)
+    deadline = time.monotonic() + (timeout_ms / 1000.0)
+    while time.monotonic() < deadline:
+        if _active_app_matches(hints):
+            return
+        runner.sleep(f"{POLL_INTERVAL_MS}ms")
+    raise RuntimeError(f"App did not become active in {timeout_ms}ms: '{app_name}'")
+
+
+def settle_after_step(action: str, runner: Any) -> None:
+    if action not in SETTLE_ACTIONS:
+        return
+    delay_ms = _int_setting("user.gpt_semantic_step_settle_ms", 180)
+    if delay_ms > 0:
+        runner.sleep(f"{delay_ms}ms")
+
+
+def _active_app_matches(hints: list[str]) -> bool:
+    try:
+        app = talon_ui.active_app() if talon_ui is not None else None
+    except Exception:
+        return False
+    current = _normalize(app.name if app is not None else "")
+    return any(_name_matches(current, hint) for hint in hints)
+
+
+def _name_matches(current: str, hint: str) -> bool:
+    return bool(current and hint and (current == hint or hint in current or current in hint))
+
+
+def _focus_hints(app_name: str, command: str | None) -> list[str]:
+    values = [_normalize(app_name)]
+    if command:
+        values.extend(_command_hints(command))
+    return [value for value in dict.fromkeys(values) if value]
+
+
+def _command_hints(command: str) -> list[str]:
+    executable = _first_token(command)
+    name = Path(executable).stem if executable else ""
+    return [_normalize(executable), _normalize(name)]
+
+
+def _first_token(command: str) -> str:
+    try:
+        parts = split(command)
+    except ValueError:
+        return command.strip().split(" ")[0]
+    return parts[0] if parts else ""
+
+
+def _int_setting(name: str, default: int) -> int:
+    if talon_settings is None:
+        return 0
+    try:
+        value = talon_settings.get(name)
+        return int(value) if value is not None else default
+    except Exception:
+        return default
+
+
+def _normalize(value: str) -> str:
+    return " ".join(value.strip().lower().replace("-", " ").split())

--- a/GPT/semantic/gpt_semantic_transport.py
+++ b/GPT/semantic/gpt_semantic_transport.py
@@ -17,7 +17,9 @@ class GptSemanticTransportError(RuntimeError):
     pass
 
 
-def request_completion(system_prompt: str, user_prompt: str, model: str, debug: bool) -> str:
+def request_completion(
+    system_prompt: str, user_prompt: str, model: str, debug: bool
+) -> str:
     helpers = _helpers()
     model_name = helpers["resolve_model_name"](model)
     endpoint = _model_endpoint()

--- a/GPT/semantic/gpt_semantic_transport.py
+++ b/GPT/semantic/gpt_semantic_transport.py
@@ -1,0 +1,71 @@
+"""Model transport adapter for semantic planning.
+
+Purpose:
+- Reuses talon-ai-tools model helper functions for API/LLM CLI routing.
+- Returns normalized assistant message text to the semantic runtime.
+
+Called from:
+- `GPT/semantic/gpt_semantic_runtime.py` during translation and repair retry.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class GptSemanticTransportError(RuntimeError):
+    pass
+
+
+def request_completion(system_prompt: str, user_prompt: str, model: str, debug: bool) -> str:
+    helpers = _helpers()
+    model_name = helpers["resolve_model_name"](model)
+    endpoint = _model_endpoint()
+    prompt = helpers["format_message"](user_prompt)
+    if debug:
+        print({"gpt_semantic_model": model_name, "endpoint": endpoint})
+    if endpoint == "llm":
+        response = helpers["send_request_to_llm_cli"](
+            prompt, None, system_prompt, model_name, False
+        )
+    else:
+        request = {"role": "user", "content": [prompt]}
+        response = helpers["send_request_to_api"](request, system_prompt, model_name)
+    return helpers["extract_message"](response)
+
+
+def _helpers() -> dict[str, Any]:
+    try:
+        from ...lib.modelHelpers import (
+            extract_message,
+            format_message,
+            resolve_model_name,
+            send_request_to_api,
+            send_request_to_llm_cli,
+        )
+    except ImportError:
+        from lib.modelHelpers import (
+            extract_message,
+            format_message,
+            resolve_model_name,
+            send_request_to_api,
+            send_request_to_llm_cli,
+        )
+    return {
+        "extract_message": extract_message,
+        "format_message": format_message,
+        "resolve_model_name": resolve_model_name,
+        "send_request_to_api": send_request_to_api,
+        "send_request_to_llm_cli": send_request_to_llm_cli,
+    }
+
+
+def _model_endpoint() -> str:
+    try:
+        from talon import settings
+    except ImportError as exc:  # pragma: no cover
+        raise GptSemanticTransportError("Talon settings are unavailable") from exc
+    endpoint = settings.get("user.model_endpoint")
+    if not isinstance(endpoint, str) or not endpoint:
+        raise GptSemanticTransportError("Setting user.model_endpoint is missing")
+    return endpoint

--- a/GPT/semantic/gpt_semantic_types.py
+++ b/GPT/semantic/gpt_semantic_types.py
@@ -7,8 +7,8 @@ Called from:
 - Parser, guardrails, runtime, executor, and prompt modules.
 """
 
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 from typing import Any
 
 ActionArgSpecs = dict[str, dict[str, type]]

--- a/GPT/semantic/gpt_semantic_types.py
+++ b/GPT/semantic/gpt_semantic_types.py
@@ -1,0 +1,59 @@
+"""Shared semantic schema types and constants.
+
+Purpose:
+- Defines allowed actions, typed plan/step data structures, and JSON serialization helpers.
+
+Called from:
+- Parser, guardrails, runtime, executor, and prompt modules.
+"""
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+ActionArgSpecs = dict[str, dict[str, type]]
+
+ACTION_ARG_SPECS: ActionArgSpecs = {
+    "switch_app": {"app_name": str},
+    "launch_app": {"app_name": str},
+    "focus_address": {},
+    "new_tab": {},
+    "go_url": {"url": str},
+    "find_text": {"text": str},
+    "insert_text": {"text": str},
+    "key": {"combo": str},
+    "sleep": {"ms": int},
+    "copy": {},
+    "paste": {},
+    "select_all": {},
+    "undo": {},
+    "redo": {},
+    "line_start": {},
+    "line_end": {},
+    "delete_selection": {},
+}
+
+ALLOWED_ACTIONS: tuple[str, ...] = tuple(ACTION_ARG_SPECS.keys())
+
+
+@dataclass(frozen=True)
+class GptSemanticStep:
+    action: str
+    args: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class GptSemanticPlan:
+    steps: list[GptSemanticStep]
+    summary: str | None = None
+
+
+def plan_to_dict(plan: GptSemanticPlan) -> dict[str, Any]:
+    payload = {"steps": [vars(step) for step in plan.steps]}
+    if plan.summary:
+        payload["summary"] = plan.summary
+    return payload
+
+
+def plan_to_json(plan: GptSemanticPlan) -> str:
+    return json.dumps(plan_to_dict(plan), indent=2)


### PR DESCRIPTION
## Summary

This PR adds a new **standalone semantic command stack** inside `GPT/semantic` for `talon-ai-tools`.

The goal is to let users speak high-level requests (for example, “model semantic open google chrome and search for …”), generate a constrained action plan, preview it, and only execute after explicit confirmation.

## Purpose

- Add `model semantic ...` voice commands with preview/run/cancel/copy/repeat flows.
- Keep runtime safety by requiring confirmation before execution and stopping on first execution error.

## Mechanics: How Semantic Commands Work

- User says `model semantic <request>`.
- Talon sends that text to the semantic runtime.
- Runtime gathers context (active app/window, running apps, launchable apps).
- Runtime builds a strict prompt with allowed actions + safety rules + user request.
- Prompt is sent via existing AI-tools transport (`llm` CLI or API endpoint).
- Model returns a JSON action plan (`steps` + optional `summary`).
- Plan is parsed and schema-validated (with one repair retry on parse/schema failure).
- Guardrails validate limits (step count, sleep budget, insert size, blocked key combos).
- If valid, plan is stored as pending and shown in preview (no execution yet).
- User can `run plan`, `cancel plan`, `copy plan`, or `repeat last`.
- On `run plan`, executor runs steps in order with focus/settle synchronization.
- Execution stops on first failure and reports the exact failed step/action.

## Examples:

Speech: model semantic open chrome and search for recent trends
Typical plan:

```json
{
  "steps": [
    {"action": "switch_app", "args": {"app_name": "Google Chrome"}},
    {"action": "new_tab", "args": {}},
    {"action": "focus_address", "args": {}},
    {"action": "insert_text", "args": {"text": "recent trends"}},
    {"action": "key", "args": {"combo": "enter"}}
  ],
  "summary": "Open Chrome and run a web search"
}
```
Speech: model semantic open gedit
Typical plan:

```json
{
  "steps": [
    {"action": "launch_app", "args": {"app_name": "gedit"}}
  ],
  "summary": "Launch text editor"
}
```
Speech: model semantic find budget in this page
Typical plan:

```json
{
  "steps": [
    {"action": "find_text", "args": {"text": "budget"}}
  ],
  "summary": "Open in-page search for budget"
}
```
Speech: model semantic go to github.com in current tab
Typical plan:

```json
{
  "steps": [
    {"action": "go_url", "args": {"url": "https://github.com"}}
  ],
  "summary": "Navigate current tab to GitHub"
}
```
Speech: model semantic select all and copy
Typical plan:

```json
{
  "steps": [
    {"action": "select_all", "args": {}},
    {"action": "copy", "args": {}}
  ],
  "summary": "Copy all content"
}
```
Speech: model semantic type hello world and press enter
Typical plan:

```json
{
  "steps": [
    {"action": "insert_text", "args": {"text": "hello world"}},
    {"action": "key", "args": {"combo": "enter"}}
  ],
  "summary": "Insert text and submit"
}
```
Speech: model semantic wait half a second then paste
Typical plan:

```json
{
  "steps": [
    {"action": "sleep", "args": {"ms": 500}},
    {"action": "paste", "args": {}}
  ],
  "summary": "Delay then paste"
}
```

## User-facing behavior added

- `model semantic <user.text>`
- `model semantic run plan`
- `model semantic cancel plan`
- `model semantic copy plan`
- `model semantic repeat last`
